### PR TITLE
HIPP-182: Fix PR bot and compiler warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,39 @@
+# API Hub Frontend
 
-# api-hub-applications
+This service provides a backend for the API Hub specific to applications.
 
-This is a placeholder README.md for a new repository
+## Summary
 
-### License
+This service provides the following functionality:
+
+* tbd
+
+## Requirements
+
+This service is written in [Scala](http://www.scala-lang.org/) and [Play](http://playframework.com/), so needs at least a [JRE] to run.
+
+## Run the application
+
+To run the application use `sbt run` to start the service. All local dependencies should be running first:
+* MongoDb
+* The API_HUB_ALL Service Manager group
+
+Once everything is up and running you can access the application at
+
+```
+http://localhost:9000/api-hub-applications
+```
+
+## Unit tests
+```
+sbt test
+```
+
+## Integration tests
+```
+sbt it:test
+```
+
+## License
 
 This code is open source software licensed under the [Apache 2.0 License]("http://www.apache.org/licenses/LICENSE-2.0.html").

--- a/app/uk/gov/hmrc/apihubapplications/controllers/MicroserviceHelloWorldController.scala
+++ b/app/uk/gov/hmrc/apihubapplications/controllers/MicroserviceHelloWorldController.scala
@@ -25,7 +25,7 @@ import scala.concurrent.Future
 class MicroserviceHelloWorldController @Inject()(cc: ControllerComponents)
     extends BackendController(cc) {
 
-  def hello(): Action[AnyContent] = Action.async { implicit request =>
+  def hello(): Action[AnyContent] = Action.async {
     Future.successful(Ok("Hello world"))
   }
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,5 +4,5 @@ resolvers += Resolver.typesafeRepo("releases")
 
 addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"     % "3.8.0")
 addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables" % "2.1.0")
-addSbtPlugin("com.typesafe.play" % "sbt-plugin"         % "2.8.16")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin"         % "2.8.18")
 addSbtPlugin("org.scoverage"     % "sbt-scoverage"      % "1.9.3")


### PR DESCRIPTION
PR bot warnings fixed:

•	Runtime issues may occur. Change com.typesafe.play.sbt-plugin to 2.8.18 in [project/plugins.sbt](https://github.com/hmrc/api-hub-applications/blob/copyright/project/plugins.sbt#L7) - to match what uk.gov.hmrc.bootstrap-backend-play-28 uses
	•	Please update [README.md](https://github.com/hmrc/api-hub-applications/blob/copyright/README.md#L4) - contains placeholder text. See https://docs.publishing.service.gov.uk/manual/readmes.html for template
