### PR TITLE
openapi spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,12 @@ This service provides a backend for the API Hub specific to applications.
 
 ## Summary
 
-This service provides the following functionality:
+This service will provide the following functionality:
 
-* tbd
+* Register a new application
+* Manage team members of an application
+* Create and rotate credentials
+* Add and remove scopes to credentials
 
 ## Requirements
 
@@ -33,6 +36,21 @@ sbt test
 ```
 sbt it:test
 ```
+
+## API Documentation
+The API is documented using the [OpenAPI specification](https://swagger.io/specification/).
+
+To see a rendered view of the documentation, install [Redocly CLI](https://redocly.com/docs/cli/installation/).
+```
+npm i -g @redocly/cli@latest
+```
+
+Then run from the root of the project:
+```
+redocly preview-docs openapi.yaml
+```
+
+Visit localhost:8080 in the browser.
 
 ## License
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -39,7 +39,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/NewApplication"
+              $ref: "#/components/schemas/RegisterApplicationRequest"
         required: true
       responses:
         200:
@@ -49,19 +49,13 @@ paths:
               schema:
                 $ref: "#/components/schemas/Application"
         400:
-          description: If some, or all, of the specified fields are missing
+          $ref: "#/components/responses/badRequest"
   /applications/{id}:
     get:
       summary: Get application by application ID
       parameters:
-        - name: id
-          in: path
-          description: The Application ID
-          required: true
-          schema:
-            type: string
-            format: "24 character hexadecimal"
-            example: "63e25c5916101c38744f727b"
+        - applications:
+          $ref: "#/components/parameters/applicationId"
       responses:
         200:
           description: A single application with the specified application ID
@@ -70,7 +64,34 @@ paths:
               schema:
                 $ref: "#/components/schemas/Application"
         404:
-          description: An application with specified ID cannot be found
+          $ref: "#/components/responses/appIdNotFound"
+  /applications/{id}/environments/scopes:
+    post:
+      summary: Add a scope to an application
+      parameters:
+        - applications:
+          $ref: "#/components/parameters/applicationId"
+      requestBody:
+        description: The scope to be added
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AddScopesRequest"
+            examples:
+              addScopesRequest:
+                $ref: "#/components/examples/addScopesRequest"
+        required: true
+      responses:
+        200:
+          description: All the details of the newly registered application
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Application"
+        400:
+          $ref: "#/components/responses/badRequest"
+        404:
+          $ref: "#/components/responses/appIdNotFound"
   /applications/pending-scopes:
     get:
       summary: Get applications with PENDING prod scopes
@@ -166,7 +187,7 @@ components:
             - "APPROVED"
             - "DENIED"
           example: "APPROVED"
-    NewApplication:
+    RegisterApplicationRequest:
       type: object
       properties:
         name:
@@ -178,6 +199,39 @@ components:
             email:
               type: string
               example: "john.smith@hmrc.gov.uk"
+    AddScopesRequest:
+      type: array
+      items:
+        type: object
+        properties:
+          name:
+            type: string
+            example: "read:address"
+          environments:
+            type: array
+            items:
+              type: string
+              enum:
+                - "dev"
+                - "test"
+                - "preProd"
+                - "prod"
+              example: "prod"
+  parameters:
+    applicationId:
+      name: id
+      in: path
+      description: The Application ID
+      required: true
+      schema:
+        type: string
+        format: "24 character hexadecimal"
+        example: "63e25c5916101c38744f727b"
+  responses:
+    badRequest:
+      description: If some, or all, of the specified fields are missing
+    appIdNotFound:
+      description: An application with specified ID cannot be found
   examples:
     applications:
       summary: A list of applications with various scope statuses
@@ -288,4 +342,16 @@ components:
     emptyListOfApplications:
       summary: An empty list of applications
       value: []
+    addScopesRequest:
+      summary: "blah"
+      value:
+        - name: read:address
+          environments:
+            - preProd
+            - prod
+        - name: write:address
+          environments:
+            - preProd
+
+
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -54,7 +54,7 @@ paths:
     get:
       summary: Get application by application ID
       parameters:
-        - applications:
+        - applicationId:
           $ref: "#/components/parameters/applicationId"
       responses:
         200:
@@ -69,7 +69,7 @@ paths:
     post:
       summary: Add a scope to an application
       parameters:
-        - applications:
+        - applicationId:
           $ref: "#/components/parameters/applicationId"
       requestBody:
         description: The scope to be added
@@ -88,6 +88,34 @@ paths:
           description: If attempting to add a scope to an environment that does not exist or if the request body does not match the required structure.
         404:
           $ref: "#/components/responses/appIdNotFound"
+  /applications/{id}/environments/{environment}/scopes/{scopename}:
+    put:
+      summary: Update the status of a scope
+      description: Currently works only to approve scopes in production.
+      parameters:
+        - applicationId:
+          $ref: "#/components/parameters/applicationId"
+        - environment:
+          $ref: "#/components/parameters/environment"
+        - scopeName:
+          $ref: "#/components/parameters/scopeName"
+      requestBody:
+        description: The status to set on the scope. Currently only supports APPROVED
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateScopeStatus"
+            examples:
+              updateScopeStatus:
+                $ref: "#/components/examples/updateScopeStatus"
+        required: true
+      responses:
+        204:
+          description: The status of the scope was updated successfully
+        400:
+          description: If the environment is not "prod" or the status is not "APPROVED".
+        404:
+          description: If the scope name cannot be found with the status of "PENDING". If an application with specified ID cannot be found
   /applications/pending-scopes:
     get:
       summary: Get applications with PENDING prod scopes
@@ -221,6 +249,16 @@ components:
                 - "preProd"
                 - "prod"
               example: "prod"
+    UpdateScopeStatus:
+      type: object
+      properties:
+        status:
+          type: string
+          enum:
+            - "PENDING"
+            - "APPROVED"
+            - "DENIED"
+          example: "APPROVED"
   parameters:
     applicationId:
       name: id
@@ -231,6 +269,27 @@ components:
         type: string
         format: "24 character hexadecimal"
         example: "63e25c5916101c38744f727b"
+    environment:
+      name: environment
+      in: path
+      description: The environment name
+      required: true
+      schema:
+        type: string
+        enum:
+          - "dev"
+          - "test"
+          - "preProd"
+          - "prod"
+        example: "prod"
+    scopeName:
+      name: scopename
+      in: path
+      description: The name of the scope
+      required: true
+      schema:
+        type: string
+        example: "read:address"
   responses:
     badRequest:
       description: If the request body does not match the required structure
@@ -347,7 +406,7 @@ components:
       summary: An empty list of applications
       value: []
     addScopesRequest:
-      summary: "blah"
+      summary: "The scopes to set against the specified environments"
       value:
         - name: read:address
           environments:
@@ -356,6 +415,10 @@ components:
         - name: write:address
           environments:
             - preProd
+    updateScopeStatus:
+      summary: "The status to set"
+      value:
+        status: APPROVED
 
 
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -20,7 +20,6 @@ paths:
   /applications:
     get:
       summary: Get all applications
-      description: Get all applications ever registered
       responses:
         200:
           description: A list of credentials to scope mappings
@@ -28,124 +27,56 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Applications"
+  /applications/{id}:
+    get:
+      summary: Get application by application ID
+      parameters:
+        - name: id
+          in: path
+          description: The Application ID
+          required: true
+          schema:
+            type: string
+            format: "24 character hexadecimal"
+            example: "63e25c5916101c38744f727b"
+      responses:
+        200:
+          description: A single application with the specified application ID
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Application"
+        404:
+          description: An application with specified ID cannot be found
+
 components:
   schemas:
     Applications:
       type: array
       items:
         $ref: "#/components/schemas/Application"
-      example:
-        [
-          {
-            "id": "63e25c5916101c38744f727b",
-            "name": "Address Weighting Service",
-            "created": "2023-02-13T14:44:00.849",
-            "email": "john.smith@hmrc.gov.uk",
-            "lastUpdated": "2023-03-01T11:23:00.583",
-            "teamMembers": [
-              {
-                "email": "john.smith@hmrc.gov.uk"
-              },
-              {
-                "email": "heather.williams@hmrc.gov.uk"
-              },
-              {
-                "email": "bob.fuller@hmrc.gov.uk"
-              }
-            ],
-            "environments": {
-              "dev": {
-                "scopes": [
-                  {
-                    "name": "scope-a",
-                    "status": "APPROVED"
-                  },
-                  {
-                    "name": "scope-b",
-                    "status": "APPROVED"
-                  }
-                ],
-                "credentials": [
-                ]
-              },
-              "test": {
-                "scopes": [ ],
-                "credentials": [
-                ]
-              },
-              "preProd": {
-                "scopes": [ ],
-                "credentials": [
-                ]
-              },
-              "prod": {
-                "scopes": [
-                  {
-                    "name": "scope-c",
-                    "status": "PENDING"
-                  }
-                ],
-                "credentials": [
-                ]
-              }
-            }
-          },
-          {
-            "id": "63e367ee896eeb2e9fccb581",
-            "name": "Keying Service",
-            "created": "2023-02-08T09:14:22.401",
-            "email": "judy.adams@digital.hmrc.gov.uk",
-            "lastUpdated": "2023-02-08T09:14:22.401",
-            "teamMembers": [
-              {
-                "email": "judy.adams@digital.hmrc.gov.uk"
-              }
-            ],
-            "environments": {
-              "dev": {
-                "scopes": [
-                ],
-                "credentials": [
-                ]
-              },
-              "test": {
-                "scopes": [
-                ],
-                "credentials": [
-                ]
-              },
-              "preProd": {
-                "scopes": [
-                ],
-                "credentials": [
-                ]
-              },
-              "prod": {
-                "scopes": [
-                ],
-                "credentials": [
-                ]
-              }
-            }
-          }
-        ]
     Application:
       type: object
       properties:
         id:
           type: string
+          example: "63e25c5916101c38744f727b"
         name:
           type: string
+          example: "Address Weighting Service"
         created:
           type: string
           format: date-time
+          example: "2023-02-13T14:44:00.849"
         createdBy:
           $ref: "#/components/schemas/CreatedBy"
         lastUpdated:
           type: string
           format: date-time
+          example: "2023-03-01T11:23:00.583"
         teamMembers:
           $ref: "#/components/schemas/TeamMembers"
+          example:
         environments:
           $ref: "#/components/schemas/Environments"
     CreatedBy:
@@ -153,6 +84,7 @@ components:
       properties:
         email:
           type: string
+          example: "john.smith@hmrc.gov.uk"
     TeamMembers:
       type: array
       items:
@@ -162,6 +94,7 @@ components:
       properties:
         email:
           type: string
+          example: "john.smith@hmrc.gov.uk"
     Environments:
       type: object
       properties:
@@ -187,9 +120,11 @@ components:
       properties:
         name:
           type: string
+          example: "read:address"
         status:
           type: string
           enum:
             - "PENDING"
             - "APPROVED"
             - "DENIED"
+          example: "APPROVED"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,0 +1,195 @@
+openapi: "3.0.1"
+info:
+  title: API Hub Applications
+  version: "1.0"
+  description: |
+    This is used by The API Hub frontend (api-hub-frontend) to create and retrieve details of applications made by users
+
+    ```
+    Change Log
+
+    ```
+
+      | Version | Date | Author | Description |
+      |---|-----|------|-----|
+      | 1.0.0 | 01-03-2023 | Laura Howarth-Kirke | Document current endpoints |
+servers:
+  - url: https://api-hub-applications.protected.mdtp/api-hub-applications
+
+paths:
+  /applications:
+    get:
+      summary: Get all applications
+      description: Get all applications ever registered
+      responses:
+        200:
+          description: A list of credentials to scope mappings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Applications"
+components:
+  schemas:
+    Applications:
+      type: array
+      items:
+        $ref: "#/components/schemas/Application"
+      example:
+        [
+          {
+            "id": "63e25c5916101c38744f727b",
+            "name": "Address Weighting Service",
+            "created": "2023-02-13T14:44:00.849",
+            "email": "john.smith@hmrc.gov.uk",
+            "lastUpdated": "2023-03-01T11:23:00.583",
+            "teamMembers": [
+              {
+                "email": "john.smith@hmrc.gov.uk"
+              },
+              {
+                "email": "heather.williams@hmrc.gov.uk"
+              },
+              {
+                "email": "bob.fuller@hmrc.gov.uk"
+              }
+            ],
+            "environments": {
+              "dev": {
+                "scopes": [
+                  {
+                    "name": "scope-a",
+                    "status": "APPROVED"
+                  },
+                  {
+                    "name": "scope-b",
+                    "status": "APPROVED"
+                  }
+                ],
+                "credentials": [
+                ]
+              },
+              "test": {
+                "scopes": [ ],
+                "credentials": [
+                ]
+              },
+              "preProd": {
+                "scopes": [ ],
+                "credentials": [
+                ]
+              },
+              "prod": {
+                "scopes": [
+                  {
+                    "name": "scope-c",
+                    "status": "PENDING"
+                  }
+                ],
+                "credentials": [
+                ]
+              }
+            }
+          },
+          {
+            "id": "63e367ee896eeb2e9fccb581",
+            "name": "Keying Service",
+            "created": "2023-02-08T09:14:22.401",
+            "email": "judy.adams@digital.hmrc.gov.uk",
+            "lastUpdated": "2023-02-08T09:14:22.401",
+            "teamMembers": [
+              {
+                "email": "judy.adams@digital.hmrc.gov.uk"
+              }
+            ],
+            "environments": {
+              "dev": {
+                "scopes": [
+                ],
+                "credentials": [
+                ]
+              },
+              "test": {
+                "scopes": [
+                ],
+                "credentials": [
+                ]
+              },
+              "preProd": {
+                "scopes": [
+                ],
+                "credentials": [
+                ]
+              },
+              "prod": {
+                "scopes": [
+                ],
+                "credentials": [
+                ]
+              }
+            }
+          }
+        ]
+    Application:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        created:
+          type: string
+          format: date-time
+        createdBy:
+          $ref: "#/components/schemas/CreatedBy"
+        lastUpdated:
+          type: string
+          format: date-time
+        teamMembers:
+          $ref: "#/components/schemas/TeamMembers"
+        environments:
+          $ref: "#/components/schemas/Environments"
+    CreatedBy:
+      type: object
+      properties:
+        email:
+          type: string
+    TeamMembers:
+      type: array
+      items:
+        $ref: "#/components/schemas/TeamMember"
+    TeamMember:
+      type: object
+      properties:
+        email:
+          type: string
+    Environments:
+      type: object
+      properties:
+        dev:
+          $ref: "#/components/schemas/Environment"
+        test:
+          $ref: "#/components/schemas/Environment"
+        preProd:
+          $ref: "#/components/schemas/Environment"
+        prod:
+          $ref: "#/components/schemas/Environment"
+    Environment:
+      type: object
+      properties:
+        scopes:
+          $ref: "#/components/schemas/Scopes"
+    Scopes:
+      type: array
+      items:
+        $ref: "#/components/schemas/Scope"
+    Scope:
+      type: object
+      properties:
+        name:
+          type: string
+        status:
+          type: string
+          enum:
+            - "PENDING"
+            - "APPROVED"
+            - "DENIED"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -19,14 +19,19 @@ servers:
 paths:
   /applications:
     get:
-      summary: Get all applications
+      summary: Get applications
       responses:
         200:
-          description: A list of credentials to scope mappings
+          description: A list of applications
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/Applications"
+              examples:
+                applications:
+                  $ref: "#/components/examples/applications"
+                emptyListOfApplications:
+                  $ref: "#/components/examples/emptyListOfApplications"
   /applications/{id}:
     get:
       summary: Get application by application ID
@@ -48,6 +53,21 @@ paths:
                 $ref: "#/components/schemas/Application"
         404:
           description: An application with specified ID cannot be found
+  /applications/pending-scopes:
+    get:
+      summary: Get applications with PENDING prod scopes
+      responses:
+        200:
+          description: A list of applications where at least one scope in prod is in the PENDING state
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Applications"
+              examples:
+                applicationsWithPendingProdScopes:
+                  $ref: "#/components/examples/applicationsWithPendingProdScopes"
+                emptyListOfApplications:
+                  $ref: "#/components/examples/emptyListOfApplications"
 
 components:
   schemas:
@@ -128,3 +148,114 @@ components:
             - "APPROVED"
             - "DENIED"
           example: "APPROVED"
+  examples:
+    applications:
+      summary: A list of applications with various scope statuses
+      value:
+        - id: 63e25c5916101c38744f727b
+          name: Address Weighting Service
+          created: '2023-02-13T14:44:00.849'
+          email: john.smith@hmrc.gov.uk
+          lastUpdated: '2023-03-01T11:23:00.583'
+          teamMembers:
+            - email: john.smith@hmrc.gov.uk
+          environments:
+            dev:
+              scopes:
+                - name: read:address
+                  status: APPROVED
+                - name: write:address
+                  status: APPROVED
+              credentials: [ ]
+            test:
+              scopes: [ ]
+              credentials: [ ]
+            preProd:
+              scopes: [ ]
+              credentials: [ ]
+            prod:
+              scopes:
+                - name: read:address
+                  status: APPROVED
+                - name: write:address
+                  status: PENDING
+              credentials: [ ]
+        - id: 63e367ee896eeb2e9fccb581
+          name: Keying Service
+          created: '2023-02-08T09:14:22.401'
+          email: judy.adams@digital.hmrc.gov.uk
+          lastUpdated: '2023-02-08T09:14:22.401'
+          teamMembers:
+            - email: judy.adams@digital.hmrc.gov.uk
+          environments:
+            dev:
+              scopes: [ ]
+              credentials: [ ]
+            test:
+              scopes: [ ]
+              credentials: [ ]
+            preProd:
+              scopes: [ ]
+              credentials: [ ]
+            prod:
+              scopes: [ ]
+              credentials: [ ]
+    applicationsWithPendingProdScopes:
+      summary: A list of applications with PENDING prod scopes
+      value:
+      - id: 63e25c5916101c38744f727b
+        name: Address Weighting Service
+        created: '2023-02-13T14:44:00.849'
+        email: john.smith@hmrc.gov.uk
+        lastUpdated: '2023-03-01T11:23:00.583'
+        teamMembers:
+          - email: john.smith@hmrc.gov.uk
+        environments:
+          dev:
+            scopes:
+              - name: read:address
+                status: APPROVED
+              - name: write:address
+                status: APPROVED
+            credentials: [ ]
+          test:
+            scopes: [ ]
+            credentials: [ ]
+          preProd:
+            scopes: [ ]
+            credentials: [ ]
+          prod:
+            scopes:
+              - name: read:address
+                status: APPROVED
+              - name: write:address
+                status: PENDING
+            credentials: [ ]
+      - id: 63e367ee896eeb2e9fccb581
+        name: Keying Service
+        created: '2023-02-08T09:14:22.401'
+        email: judy.adams@digital.hmrc.gov.uk
+        lastUpdated: '2023-02-08T09:14:22.401'
+        teamMembers:
+          - email: judy.adams@digital.hmrc.gov.uk
+        environments:
+          dev:
+            scopes: [ ]
+            credentials: [ ]
+          test:
+            scopes:
+              - name: read:address
+                status: APPROVED
+            credentials: [ ]
+          preProd:
+            scopes: [ ]
+            credentials: [ ]
+          prod:
+            scopes:
+              - name: write:address
+                status: PENDING
+            credentials: [ ]
+    emptyListOfApplications:
+      summary: An empty list of applications
+      value: []
+

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -199,6 +199,14 @@ components:
             email:
               type: string
               example: "john.smith@hmrc.gov.uk"
+        teamMembers:
+          type: array
+          items:
+            type: object
+            properties:
+              email:
+                type: string
+                example: john.smith@hmrc.gov.uk
     AddScopesRequest:
       type: array
       items:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -42,7 +42,7 @@ paths:
               $ref: "#/components/schemas/RegisterApplicationRequest"
         required: true
       responses:
-        200:
+        201:
           description: All the details of the newly registered application
           content:
             application/json:
@@ -82,14 +82,10 @@ paths:
                 $ref: "#/components/examples/addScopesRequest"
         required: true
       responses:
-        200:
-          description: All the details of the newly registered application
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Application"
+        204:
+          description: The scopes were added to the environments successfully
         400:
-          $ref: "#/components/responses/badRequest"
+          description: If attempting to add a scope to an environment that does not exist or if the request body does not match the required structure.
         404:
           $ref: "#/components/responses/appIdNotFound"
   /applications/pending-scopes:
@@ -237,7 +233,7 @@ components:
         example: "63e25c5916101c38744f727b"
   responses:
     badRequest:
-      description: If some, or all, of the specified fields are missing
+      description: If the request body does not match the required structure
     appIdNotFound:
       description: An application with specified ID cannot be found
   examples:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -32,6 +32,24 @@ paths:
                   $ref: "#/components/examples/applications"
                 emptyListOfApplications:
                   $ref: "#/components/examples/emptyListOfApplications"
+    post:
+      summary: Register a new application
+      requestBody:
+        description: The minimal data needed to register a new application
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/NewApplication"
+        required: true
+      responses:
+        200:
+          description: All the details of the newly registered application
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Application"
+        400:
+          description: If some, or all, of the specified fields are missing
   /applications/{id}:
     get:
       summary: Get application by application ID
@@ -83,7 +101,7 @@ components:
           example: "63e25c5916101c38744f727b"
         name:
           type: string
-          example: "Address Weighting Service"
+          example: "address-weighting-service"
         created:
           type: string
           format: date-time
@@ -148,12 +166,24 @@ components:
             - "APPROVED"
             - "DENIED"
           example: "APPROVED"
+    NewApplication:
+      type: object
+      properties:
+        name:
+          type: string
+          example: "address-weighting-service"
+        createdBy:
+          type: object
+          properties:
+            email:
+              type: string
+              example: "john.smith@hmrc.gov.uk"
   examples:
     applications:
       summary: A list of applications with various scope statuses
       value:
         - id: 63e25c5916101c38744f727b
-          name: Address Weighting Service
+          name: address-weighting-service
           created: '2023-02-13T14:44:00.849'
           email: john.smith@hmrc.gov.uk
           lastUpdated: '2023-03-01T11:23:00.583'
@@ -181,7 +211,7 @@ components:
                   status: PENDING
               credentials: [ ]
         - id: 63e367ee896eeb2e9fccb581
-          name: Keying Service
+          name: keying-service
           created: '2023-02-08T09:14:22.401'
           email: judy.adams@digital.hmrc.gov.uk
           lastUpdated: '2023-02-08T09:14:22.401'
@@ -204,7 +234,7 @@ components:
       summary: A list of applications with PENDING prod scopes
       value:
       - id: 63e25c5916101c38744f727b
-        name: Address Weighting Service
+        name: address-weighting-service
         created: '2023-02-13T14:44:00.849'
         email: john.smith@hmrc.gov.uk
         lastUpdated: '2023-03-01T11:23:00.583'
@@ -232,7 +262,7 @@ components:
                 status: PENDING
             credentials: [ ]
       - id: 63e367ee896eeb2e9fccb581
-        name: Keying Service
+        name: keying-service
         created: '2023-02-08T09:14:22.401'
         email: judy.adams@digital.hmrc.gov.uk
         lastUpdated: '2023-02-08T09:14:22.401'


### PR DESCRIPTION
I've added an openapi spec to the project for several reasons: 

1. It is the same format that will be used when APIs are added to the API Catalogue. This gives us chance to get familiar with the technology. 
2. It provides an easy to read view of the API for less technical team members 
3. It may be useful for QA when testing

Obviously it means keeping it up to date when we make endpoint changes but the base is there, so it shouldn't take much upkeep.