### PR TITLE
HIPP-530: Stick with /api-hub URL

### DIFF
--- a/conf/app.routes
+++ b/conf/app.routes
@@ -8,5 +8,3 @@ PUT        /applications/:id/environments/:environment/scopes/:scopename        
 GET        /applications/pending-scopes                                             uk.gov.hmrc.apihubapplications.controllers.ApplicationsController.pendingScopes
 GET        /applications                                                            uk.gov.hmrc.apihubapplications.controllers.ApplicationsController.getApplications(teamMember: Option[String] ?= None)
 GET        /applications/:id                                                        uk.gov.hmrc.apihubapplications.controllers.ApplicationsController.getApplication(id: String)
-
-GET        /connectivity-test                                                       uk.gov.hmrc.apihubapplications.controllers.ConnectivityTestController.testing123

--- a/conf/prod.routes
+++ b/conf/prod.routes
@@ -3,3 +3,6 @@
 ->         /                          health.Routes
 
 GET        /admin/metrics             com.kenshoo.play.metrics.MetricsController.metrics
+
+
+GET        /api-hub/connectivity-test         uk.gov.hmrc.apihubapplications.controllers.ConnectivityTestController.testing123


### PR DESCRIPTION
HIPP-529 is a SUP and wants the URL to be /api-hub/connectivity-test. HIPP-530 needs to harmonise with that.

Changing the URL from:
/api-hub-applications/connectivity-test

To:
/api-hub/connectivity-test