### PR TITLE
HIPP-568: update scope status endpoint to handle primary instead of prod

### DIFF
--- a/app/uk/gov/hmrc/apihubapplications/controllers/ApplicationsController.scala
+++ b/app/uk/gov/hmrc/apihubapplications/controllers/ApplicationsController.scala
@@ -75,7 +75,7 @@ class ApplicationsController @Inject()(identify: IdentifierAction,
   }
 
   def addScopes(id: String): Action[JsValue] = identify.compose(Action(parse.json)).async {
-    request: Request[JsValue] => {
+    implicit request: Request[JsValue] => {
       val jsReq = request.body
       jsReq.validate[Seq[NewScope]] match {
         case JsSuccess(scopes, _) =>

--- a/app/uk/gov/hmrc/apihubapplications/controllers/ApplicationsController.scala
+++ b/app/uk/gov/hmrc/apihubapplications/controllers/ApplicationsController.scala
@@ -89,8 +89,8 @@ class ApplicationsController @Inject() (identify: IdentifierAction,
     }
   }
 
-  def pendingScopes: Action[AnyContent] = identify.compose(Action).async {
-    applicationsService.getApplicationsWithPendingScope().map(Json.toJson(_)).map(Ok(_))
+  def pendingPrimaryScopes: Action[AnyContent] = identify.compose(Action).async {
+    applicationsService.getApplicationsWithPendingPrimaryScope.map(Json.toJson(_)).map(Ok(_))
   }
 
   def updatePrimaryScopeStatus(id: String, scopeName: String): Action[JsValue] =

--- a/app/uk/gov/hmrc/apihubapplications/services/ApplicationsService.scala
+++ b/app/uk/gov/hmrc/apihubapplications/services/ApplicationsService.scala
@@ -89,19 +89,19 @@ class ApplicationsService @Inject()(
       case None => Future.successful(false)
     }
 
-  def setPendingProdScopeStatusToApproved(applicationId: String, scopeName:String): Future[Option[Boolean]] = {
+  def setPendingPrimaryScopeStatusToApproved(applicationId: String, scopeName:String): Future[Option[Boolean]] = {
     repository.findById(applicationId).flatMap {
       case Some(application)  =>
-        if (application.getProdScopes.exists(scope => scope.name == scopeName && scope.status == Pending)){
-          val updatedApp: Application = application.setProdScopes(
-            application.environments.prod.scopes.map(scope =>
-              if (scope.name == scopeName) scope.copy(status = Approved) else scope
-            )).copy(lastUpdated = LocalDateTime.now(clock))
+        if (application.getPrimaryScopes.exists(scope => scope.name == scopeName && scope.status == Pending)) {
+          val updatedScopes = application.getPrimaryScopes.map {
+            case scope if scope.name == scopeName => scope.copy(status = Approved)
+            case scope => scope
+          }
+          val updatedApp: Application = application.setPrimaryScopes(updatedScopes).copy(lastUpdated = LocalDateTime.now(clock))
           repository.update(updatedApp).map(Some(_))
-        }else{
+        } else {
           Future.successful(Some(false))
         }
-
       case None => Future.successful(None)
     }
   }

--- a/app/uk/gov/hmrc/apihubapplications/services/ApplicationsService.scala
+++ b/app/uk/gov/hmrc/apihubapplications/services/ApplicationsService.scala
@@ -74,7 +74,7 @@ class ApplicationsService @Inject()(
     }
   }
 
-  def getApplicationsWithPendingScope(): Future[Seq[Application]] = findAll().map(_.filter(_.hasProdPendingScope))
+  def getApplicationsWithPendingPrimaryScope: Future[Seq[Application]] = findAll().map(_.filter(_.hasPrimaryPendingScope))
 
   def addScopes(applicationId: String, newScopes: Seq[NewScope]): Future[Boolean] =
     repository.findById(applicationId).flatMap {

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -4,7 +4,7 @@ POST       /applications                                                        
 POST       /applications/:id/environments/scopes                                    uk.gov.hmrc.apihubapplications.controllers.ApplicationsController.addScopes(id: String)
 POST       /applications/:id/environments/primary/credentials/secret                uk.gov.hmrc.apihubapplications.controllers.ApplicationsController.createPrimarySecret(id: String)
 
-PUT        /applications/:id/environments/:environment/scopes/:scopename            uk.gov.hmrc.apihubapplications.controllers.ApplicationsController.approveProdScopeStatus(id:String,environment:String, scopename:String)
+PUT        /applications/:id/environments/primary/scopes/:scopeName                 uk.gov.hmrc.apihubapplications.controllers.ApplicationsController.updatePrimaryScopeStatus(id:String, scopeName:String)
 
 GET        /applications/pending-scopes                                             uk.gov.hmrc.apihubapplications.controllers.ApplicationsController.pendingScopes
 GET        /applications                                                            uk.gov.hmrc.apihubapplications.controllers.ApplicationsController.getApplications(teamMember: Option[String] ?= None)

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -6,6 +6,6 @@ POST       /applications/:id/environments/primary/credentials/secret            
 
 PUT        /applications/:id/environments/primary/scopes/:scopeName                 uk.gov.hmrc.apihubapplications.controllers.ApplicationsController.updatePrimaryScopeStatus(id:String, scopeName:String)
 
-GET        /applications/pending-scopes                                             uk.gov.hmrc.apihubapplications.controllers.ApplicationsController.pendingScopes
+GET        /applications/pending-primary-scopes                                     uk.gov.hmrc.apihubapplications.controllers.ApplicationsController.pendingPrimaryScopes
 GET        /applications                                                            uk.gov.hmrc.apihubapplications.controllers.ApplicationsController.getApplications(teamMember: Option[String] ?= None)
 GET        /applications/:id                                                        uk.gov.hmrc.apihubapplications.controllers.ApplicationsController.getApplication(id: String)

--- a/it/uk/gov/hmrc/apihubapplications/ApplicationsIntegrationSpec.scala
+++ b/it/uk/gov/hmrc/apihubapplications/ApplicationsIntegrationSpec.scala
@@ -316,23 +316,23 @@ class ApplicationsIntegrationSpec
   }
 
   "GET pending scopes" should {
-    "respond with a 200 and a list applications that have at least one status of pending for prod" in {
+    "respond with a 200 and a list applications that have at least one primary scope with status of pending" in {
       forAll { (application1: Application, application2: Application) =>
-        val appWithPendingTestScopes = application1.withEmptyScopes.withTestPendingScopes
-        val appWithPendingProdScopes = application2.withEmptyScopes.withProdPendingScopes.withProdApprovedScopes
+        val appWithPendingSecondaryScopes = application1.withEmptyScopes.withSecondaryPendingScopes
+        val appWithPendingPrimaryScopes = application2.withEmptyScopes.withPrimaryPendingScopes.withPrimaryApprovedScopes
 
         deleteAll().futureValue
-        insert(appWithPendingTestScopes).futureValue
-        insert(appWithPendingProdScopes).futureValue
+        insert(appWithPendingSecondaryScopes).futureValue
+        insert(appWithPendingPrimaryScopes).futureValue
 
         val response = wsClient
-          .url(s"$baseUrl/api-hub-applications/applications/pending-scopes")
+          .url(s"$baseUrl/api-hub-applications/applications/pending-primary-scopes")
           .addHttpHeaders(("Accept", "application/json"))
           .get()
           .futureValue
 
         response.status shouldBe 200
-        response.json shouldBe Json.toJson(Seq(appWithPendingProdScopes))
+        response.json shouldBe Json.toJson(Seq(appWithPendingPrimaryScopes))
       }
     }
   }

--- a/it/uk/gov/hmrc/apihubapplications/ApplicationsIntegrationSpec.scala
+++ b/it/uk/gov/hmrc/apihubapplications/ApplicationsIntegrationSpec.scala
@@ -391,8 +391,8 @@ class ApplicationsIntegrationSpec
       forAll { (application: Application) =>
         deleteAll().futureValue
 
-        val appWithPendingProdScope = application.withEmptyScopes.withPrimaryApprovedScopes
-        insert(appWithPendingProdScope).futureValue
+        val appWithPendingPrimaryScope = application.withEmptyScopes.withPrimaryApprovedScopes
+        insert(appWithPendingPrimaryScope).futureValue
 
         val response =
           wsClient

--- a/test-common/uk/gov/hmrc/apihubapplications/testhelpers/ApplicationTestLenses.scala
+++ b/test-common/uk/gov/hmrc/apihubapplications/testhelpers/ApplicationTestLenses.scala
@@ -43,6 +43,10 @@ object ApplicationTestLenses {
       application.addProdScope(Scope(approvedScopeName, Approved))
     }
 
+    def withSecondaryPendingScopes: Application = {
+      application.addSecondaryScope(Scope(pendingScopeName, Pending))
+    }
+
     def withPrimaryPendingScopes: Application = {
       application.addPrimaryScope(Scope(pendingScopeName, Pending))
     }

--- a/test-common/uk/gov/hmrc/apihubapplications/testhelpers/ApplicationTestLenses.scala
+++ b/test-common/uk/gov/hmrc/apihubapplications/testhelpers/ApplicationTestLenses.scala
@@ -43,6 +43,14 @@ object ApplicationTestLenses {
       application.addProdScope(Scope(approvedScopeName, Approved))
     }
 
+    def withPrimaryPendingScopes: Application = {
+      application.addPrimaryScope(Scope(pendingScopeName, Pending))
+    }
+
+    def withPrimaryApprovedScopes: Application = {
+      application.addPrimaryScope(Scope(approvedScopeName, Approved))
+    }
+
     def withPrimaryCredentialClientIdOnly: Application = {
       application.setPrimaryCredentials(Seq(Credential(clientId,None,None)))
     }

--- a/test/uk/gov/hmrc/apihubapplications/controllers/ApplicationsControllerSpec.scala
+++ b/test/uk/gov/hmrc/apihubapplications/controllers/ApplicationsControllerSpec.scala
@@ -277,21 +277,17 @@ class ApplicationsControllerSpec
   }
 
   "pendingScopes" - {
-    "must return 200 and only applications with pending production scopes" in {
-      val application1 = testApplication
-        .addProdScope(Scope("app-1-scope-1", Pending))
-        .addProdScope(Scope("app-1-scope-2", Approved))
-
-      val application6 = testApplication
-        .addProdScope(Scope("app-6-scope-1", Pending))
-
-      val expected = Seq(application1, application6)
-
+    "must return 200 and applications determined to have primary pending scopes" in {
       val fixture = buildFixture()
-      when(fixture.applicationsService.getApplicationsWithPendingScope()).thenReturn(Future.successful(Seq(application1, application6)))
 
+      val app1 = testApplication.addPrimaryScope(Scope("app-1-scope-1", Pending)).addPrimaryScope(Scope("app-1-scope-2", Approved))
+      val app2 = testApplication.addPrimaryScope(Scope("app-2-scope-1", Pending))
+
+      when(fixture.applicationsService.getApplicationsWithPendingPrimaryScope).thenReturn(Future.successful(Seq(app1, app2)))
+
+      val expected = Seq(app1, app2)
       running(fixture.application) {
-        val request = FakeRequest(GET, routes.ApplicationsController.pendingScopes.url)
+        val request = FakeRequest(GET, routes.ApplicationsController.pendingPrimaryScopes.url)
 
         val result = route(fixture.application, request).value
 

--- a/test/uk/gov/hmrc/apihubapplications/controllers/ApplicationsControllerSpec.scala
+++ b/test/uk/gov/hmrc/apihubapplications/controllers/ApplicationsControllerSpec.scala
@@ -309,8 +309,7 @@ class ApplicationsControllerSpec
     "must return 204 NoContent when the scope exists and is currently PENDING" in {
       val fixture = buildFixture()
       running(fixture.application) {
-        val pendingPrimaryScopeUpdated = Some(true)
-        when(fixture.applicationsService.setPendingPrimaryScopeStatusToApproved(appId, scopeName)).thenReturn(Future.successful(pendingPrimaryScopeUpdated))
+        when(fixture.applicationsService.setPendingPrimaryScopeStatusToApproved(appId, scopeName)).thenReturn(Future.successful(Some(true)))
 
         val request = requestUpdateStatus(UpdateScopeStatus(Approved))
 
@@ -322,8 +321,7 @@ class ApplicationsControllerSpec
     "must return 404 Not Found when trying to set scope status on an application that does not exist" in {
       val fixture = buildFixture()
       running(fixture.application) {
-        val appIdDoesNotExist = None
-        when(fixture.applicationsService.setPendingPrimaryScopeStatusToApproved(appId, scopeName)).thenReturn(Future.successful(appIdDoesNotExist))
+        when(fixture.applicationsService.setPendingPrimaryScopeStatusToApproved(appId, scopeName)).thenReturn(Future.successful(None))
 
         val request = requestUpdateStatus(UpdateScopeStatus(Approved))
 
@@ -335,8 +333,7 @@ class ApplicationsControllerSpec
     "must return 404 Not Found when the scope does not exist" in {
       val fixture = buildFixture()
       running(fixture.application) {
-        val scopeDoesNotExist = Some(false)
-        when(fixture.applicationsService.setPendingPrimaryScopeStatusToApproved(appId, scopeName)).thenReturn(Future.successful(scopeDoesNotExist))
+        when(fixture.applicationsService.setPendingPrimaryScopeStatusToApproved(appId, scopeName)).thenReturn(Future.successful(Some(false)))
 
         val request = requestUpdateStatus(UpdateScopeStatus(Approved))
 
@@ -348,8 +345,7 @@ class ApplicationsControllerSpec
     "must return 404 Not Found when trying to set scope status to APPROVED on an existing scope where the status is not PENDING" in {
       val fixture = buildFixture()
       running(fixture.application) {
-        val scopeExistsButIsNotPending = Some(false)
-        when(fixture.applicationsService.setPendingPrimaryScopeStatusToApproved(appId, scopeName)).thenReturn(Future.successful(scopeExistsButIsNotPending))
+        when(fixture.applicationsService.setPendingPrimaryScopeStatusToApproved(appId, scopeName)).thenReturn(Future.successful(Some(false)))
 
         val request = requestUpdateStatus(UpdateScopeStatus(Approved))
 

--- a/test/uk/gov/hmrc/apihubapplications/controllers/ApplicationsControllerSpec.scala
+++ b/test/uk/gov/hmrc/apihubapplications/controllers/ApplicationsControllerSpec.scala
@@ -301,106 +301,72 @@ class ApplicationsControllerSpec
     }
   }
 
-  "set scope to APPROVED" - {
-    "must return 204 NoContent" in {
-      val appId = "1"
-      val envName = "prod"
-      val scopeName = "test-scope-name"
-      val updateScope: UpdateScopeStatus = UpdateScopeStatus(Approved)
-      val json = Json.toJson(updateScope)
+
+  "set scope to APPROVED for primary PENDING scope" - {
+    val appId = "my-app-id"
+    val scopeName = "test-scope-name"
+
+    def requestUpdateStatus(update: UpdateScopeStatus) = FakeRequest(PUT, routes.ApplicationsController.updatePrimaryScopeStatus(appId, scopeName).url)
+      .withHeaders(CONTENT_TYPE -> "application/json")
+      .withBody(Json.toJson(update))
+
+    "must return 204 NoContent when the scope exists and is currently PENDING" in {
       val fixture = buildFixture()
       running(fixture.application) {
-        when(fixture.applicationsService.setPendingProdScopeStatusToApproved(appId, scopeName)).thenReturn(Future.successful(Some(true)))
+        val pendingPrimaryScopeUpdated = Some(true)
+        when(fixture.applicationsService.setPendingPrimaryScopeStatusToApproved(appId, scopeName)).thenReturn(Future.successful(pendingPrimaryScopeUpdated))
 
-        val request = FakeRequest(PUT, routes.ApplicationsController.approveProdScopeStatus(appId, envName, scopeName).url)
-          .withHeaders(
-            CONTENT_TYPE -> "application/json"
-          )
-          .withBody(json)
+        val request = requestUpdateStatus(UpdateScopeStatus(Approved))
 
         val result = route(fixture.application, request).value
         status(result) mustBe NoContent.code
-
-        verify(fixture.applicationsService).setPendingProdScopeStatusToApproved(ArgumentMatchers.eq(appId), ArgumentMatchers.eq(scopeName))
       }
     }
-    "must return 404 Not Found when trying to set scope status on the application that does not exist in DB" in {
-      val appId = "not-exist"
-      val envName = "prod"
-      val scopeName = "test-scope-name"
-      val updateScope: UpdateScopeStatus = UpdateScopeStatus(Approved)
-      val json = Json.toJson(updateScope)
+
+    "must return 404 Not Found when trying to set scope status on an application that does not exist" in {
       val fixture = buildFixture()
       running(fixture.application) {
-        when(fixture.applicationsService.setPendingProdScopeStatusToApproved(appId, scopeName)).thenReturn(Future.successful(Some(false)))
+        val appIdDoesNotExist = None
+        when(fixture.applicationsService.setPendingPrimaryScopeStatusToApproved(appId, scopeName)).thenReturn(Future.successful(appIdDoesNotExist))
 
-        val request = FakeRequest(PUT, routes.ApplicationsController.approveProdScopeStatus(appId, envName, scopeName).url)
-          .withHeaders(
-            CONTENT_TYPE -> "application/json"
-          )
-          .withBody(json)
+        val request = requestUpdateStatus(UpdateScopeStatus(Approved))
 
         val result = route(fixture.application, request).value
         status(result) mustBe Status.NOT_FOUND
-
-        verify(fixture.applicationsService).setPendingProdScopeStatusToApproved(ArgumentMatchers.eq(appId), ArgumentMatchers.eq(scopeName))
       }
     }
-    "must return 404 Not Found when trying to set scope status to APPROVED on prod env when existing status is not PENDING" in {
-      val appId = "not-exist"
-      val envName = "prod"
-      val scopeName = "test-scope-name"
-      val updateScope: UpdateScopeStatus = UpdateScopeStatus(Approved)
-      val json = Json.toJson(updateScope)
+
+    "must return 404 Not Found when the scope does not exist" in {
       val fixture = buildFixture()
       running(fixture.application) {
-        when(fixture.applicationsService.setPendingProdScopeStatusToApproved(appId, scopeName)).thenReturn(Future.successful(None))
+        val scopeDoesNotExist = Some(false)
+        when(fixture.applicationsService.setPendingPrimaryScopeStatusToApproved(appId, scopeName)).thenReturn(Future.successful(scopeDoesNotExist))
 
-        val request = FakeRequest(PUT, routes.ApplicationsController.approveProdScopeStatus(appId, envName, scopeName).url)
-          .withHeaders(
-            CONTENT_TYPE -> "application/json"
-          )
-          .withBody(json)
+        val request = requestUpdateStatus(UpdateScopeStatus(Approved))
 
         val result = route(fixture.application, request).value
         status(result) mustBe Status.NOT_FOUND
-
-        verify(fixture.applicationsService).setPendingProdScopeStatusToApproved(ArgumentMatchers.eq(appId), ArgumentMatchers.eq(scopeName))
       }
     }
 
-    "must return 400 Invalid Request when trying to set scope status on environment to other than prod" in {
-      val appId = "not-exist"
-      val envName = "dev"
-      val scopeName = "test-scope-name"
-      val updateScope: UpdateScopeStatus = UpdateScopeStatus(Approved)
-      val json = Json.toJson(updateScope)
+    "must return 404 Not Found when trying to set scope status to APPROVED on an existing scope where the status is not PENDING" in {
       val fixture = buildFixture()
       running(fixture.application) {
+        val scopeExistsButIsNotPending = Some(false)
+        when(fixture.applicationsService.setPendingPrimaryScopeStatusToApproved(appId, scopeName)).thenReturn(Future.successful(scopeExistsButIsNotPending))
 
-        val request = FakeRequest(PUT, routes.ApplicationsController.approveProdScopeStatus(appId, envName, scopeName).url)
-          .withHeaders(
-            CONTENT_TYPE -> "application/json"
-          )
-          .withBody(json)
+        val request = requestUpdateStatus(UpdateScopeStatus(Approved))
 
         val result = route(fixture.application, request).value
-        status(result) mustBe Status.BAD_REQUEST
+        status(result) mustBe Status.NOT_FOUND
       }
     }
-    "must return 400 Invalid Request when trying to set scope status on prod environment to other than APPROVED" in {
-      val appId = "not-exist"
-      val envName = "prod"
-      val scopeName = "test-scope-name"
-      val updateScope: UpdateScopeStatus = UpdateScopeStatus(Pending)
-      val json = Json.toJson(updateScope)
+
+    "must return 400 BadRequest when trying to set scope status to anything other than APPROVED" in {
       val fixture = buildFixture()
       running(fixture.application) {
-        val request = FakeRequest(PUT, routes.ApplicationsController.approveProdScopeStatus(appId, envName, scopeName).url)
-          .withHeaders(
-            CONTENT_TYPE -> "application/json"
-          )
-          .withBody(json)
+        val request = requestUpdateStatus(UpdateScopeStatus(Pending))
+
         val result = route(fixture.application, request).value
         status(result) mustBe Status.BAD_REQUEST
       }

--- a/test/uk/gov/hmrc/apihubapplications/models/applications/ApplicationLensesSpec.scala
+++ b/test/uk/gov/hmrc/apihubapplications/models/applications/ApplicationLensesSpec.scala
@@ -330,9 +330,7 @@ class ApplicationLensesSpec extends AnyFreeSpec with Matchers with LensBehaviour
         val application = testApplication
           .addPrimaryScope(Scope(randomString(), Approved))
           .addPrimaryScope(Scope(randomString(), Denied))
-          .addPreProdScope(Scope(randomString(), Pending))
-          .addTestScope(Scope(randomString(), Pending))
-          .addDevScope(Scope(randomString(), Pending))
+          .addSecondaryScope(Scope(randomString(), Pending))
 
         application.hasPrimaryPendingScope mustBe false
       }

--- a/test/uk/gov/hmrc/apihubapplications/services/ApplicationsServiceSpec.scala
+++ b/test/uk/gov/hmrc/apihubapplications/services/ApplicationsServiceSpec.scala
@@ -113,7 +113,7 @@ class ApplicationsServiceSpec
 
       service.registerApplication(newApplication)(HeaderCarrier()) map {
         actual =>
-          actual.left.value mustBe a [IdmsException]
+          actual.left.value mustBe a[IdmsException]
           verifyZeroInteractions(repository.insert(any()))
           succeed
       }
@@ -139,7 +139,7 @@ class ApplicationsServiceSpec
 
       service.registerApplication(newApplication)(HeaderCarrier()) map {
         actual =>
-          actual.left.value mustBe a [IdmsException]
+          actual.left.value mustBe a[IdmsException]
           verifyZeroInteractions(repository.insert(any()))
           succeed
       }
@@ -284,32 +284,30 @@ class ApplicationsServiceSpec
       val service = new ApplicationsService(repository, clock, idmsConnector)
       service.findById(id)(HeaderCarrier()).map {
         result =>
-          result.value.left.value mustBe a [IdmsException]
+          result.value.left.value mustBe a[IdmsException]
       }
     }
   }
 
- "get apps where prod env had pending scopes" -{
-   "get pending scopes" in {
-     val appWithProdPending = Application(Some(UUID.randomUUID().toString), "test-app-name", Creator("test@email.com"), Seq.empty)
-                                              .addScopes(Prod, Seq("test-scope-1"))
-     val appWithoutPending = Application(Some(UUID.randomUUID().toString), "test-app-name", Creator("test@email.com"), Seq.empty)
-                                              .addScopes(Dev, Seq("test-scope-2"))
+  "get apps where primary env has pending scopes" - {
+    val appWithPrimaryPending = Application(Some(UUID.randomUUID().toString), "test-app-name", Creator("test@email.com"), Seq.empty)
+      .addPrimaryScope(Scope("test-scope-1", Pending))
+    val appWithSecondaryPending = Application(Some(UUID.randomUUID().toString), "test-app-name", Creator("test@email.com"), Seq.empty)
+      .addSecondaryScope(Scope("test-scope-2", Pending))
 
-     val repository = mock[ApplicationsRepository]
-     when(repository.findAll()).thenReturn(Future.successful(Seq(appWithProdPending,appWithoutPending)))
+    val repository = mock[ApplicationsRepository]
+    when(repository.findAll()).thenReturn(Future.successful(Seq(appWithPrimaryPending, appWithSecondaryPending)))
 
-     val idmsConnector = mock[IdmsConnector]
+    val idmsConnector = mock[IdmsConnector]
 
-     val service = new ApplicationsService(repository, clock, idmsConnector)
-     service.getApplicationsWithPendingScope() map {
-       actual =>
-         actual mustBe Seq(appWithProdPending)
-         verify(repository).findAll()
-         succeed
-     }
-   }
- }
+    val service = new ApplicationsService(repository, clock, idmsConnector)
+    service.getApplicationsWithPendingPrimaryScope map {
+      actual =>
+        actual mustBe Seq(appWithPrimaryPending)
+        verify(repository).findAll()
+        succeed
+    }
+  }
 
   "addScopes" - {
 
@@ -319,8 +317,8 @@ class ApplicationsServiceSpec
       val service = new ApplicationsService(repository, clock, idmsConnector)
 
       val newScopes = Seq(
-       NewScope("test-name-1", Seq(Primary)),
-       NewScope("test-name-2", Seq(Secondary, Primary))
+        NewScope("test-name-1", Seq(Primary)),
+        NewScope("test-name-2", Seq(Secondary, Primary))
       )
 
       val testAppId = "test-app-id"
@@ -414,7 +412,7 @@ class ApplicationsServiceSpec
       )
 
       val testAppId = "test-app-id"
-      val app  = Application(
+      val app = Application(
         id = Some(testAppId),
         name = testAppId,
         created = LocalDateTime.now(clock),
@@ -526,8 +524,8 @@ class ApplicationsServiceSpec
     }
 
     "must map successful results correctly" in {
-      val clientResponse1 =  ClientResponse("test-client-id-1", "test-secret-1")
-      val clientResponse2 =  ClientResponse("test-client-id-2", "test-secret-2")
+      val clientResponse1 = ClientResponse("test-client-id-1", "test-secret-1")
+      val clientResponse2 = ClientResponse("test-client-id-2", "test-secret-2")
 
       val actual = ApplicationsService.FetchCredentialsMapper.mapToCredential(
         Seq(
@@ -545,8 +543,8 @@ class ApplicationsServiceSpec
     }
 
     "must return IdmsException if any individual result has failed" in {
-      val clientResponse1 =  ClientResponse("test-client-id-1", "test-secret-1")
-      val clientResponse2 =  ClientResponse("test-client-id-2", "test-secret-2")
+      val clientResponse1 = ClientResponse("test-client-id-1", "test-secret-1")
+      val clientResponse2 = ClientResponse("test-client-id-2", "test-secret-2")
 
       val actual = ApplicationsService.FetchCredentialsMapper.mapToCredential(
         Seq(
@@ -556,7 +554,7 @@ class ApplicationsServiceSpec
         )
       )
 
-      actual.left.value mustBe a [IdmsException]
+      actual.left.value mustBe a[IdmsException]
     }
   }
 

--- a/test/uk/gov/hmrc/apihubapplications/services/ApplicationsServiceSpec.scala
+++ b/test/uk/gov/hmrc/apihubapplications/services/ApplicationsServiceSpec.scala
@@ -486,15 +486,6 @@ class ApplicationsServiceSpec
       val service = new ApplicationsService(repository, clock, idmsConnector)
       val scopeName = "test-scope-1"
 
-      val envs = Environments(
-        Environment(Seq.empty, Seq.empty),
-        Environment(Seq.empty, Seq.empty),
-        Environment(Seq.empty, Seq.empty),
-        Environment(Seq.empty, Seq.empty),
-        Environment(Seq.empty, Seq.empty),
-        Environment(Seq.empty, Seq.empty)
-      )
-
       val testAppId = "test-app-id"
       val app = Application(
         id = Some(testAppId),
@@ -503,7 +494,7 @@ class ApplicationsServiceSpec
         createdBy = Creator("test-email"),
         lastUpdated = LocalDateTime.now(clock),
         teamMembers = Seq(TeamMember(email = "test-email")),
-        environments = envs
+        environments = Environments()
       )
 
       when(repository.findById(ArgumentMatchers.eq(testAppId))).thenReturn(Future.successful(Some(app)))


### PR DESCRIPTION
I've changed the behaviour of the update scope status endpoint such that previously it would return a 400 BadRequest if you tried to request an environment other that prod. Now it returns a 404 NotFound. This was to simplify the code and to be consistent with other hard coded endpoints.

I've also changed the /applications/pending-scopes endpoint to /applications/pending-primary-scopes so this will need to be updated in HIPP-567 (I'll update the ticket now).