### PR TITLE
HIPP-747: Remove unused ConnectivityTestController endpoint

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -19,17 +19,6 @@ include "backend.conf"
 
 appName = api-hub-applications
 
-# Provides an implementation of AuditConnector. Use `uk.gov.hmrc.play.audit.AuditModule` or create your own.
-# An audit connector must be provided.
-play.modules.enabled += "uk.gov.hmrc.play.audit.AuditModule"
-
-# Provides an implementation of MetricsFilter. Use `uk.gov.hmrc.play.graphite.GraphiteMetricsModule` or create your own.
-# A metric filter must be provided
-play.modules.enabled += "uk.gov.hmrc.play.bootstrap.graphite.GraphiteMetricsModule"
-
-# Provides an implementation and configures all filters required by a Platform frontend microservice.
-play.modules.enabled += "uk.gov.hmrc.play.bootstrap.backend.BackendModule"
-
 # Default http client
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientModule"
 

--- a/conf/external.routes
+++ b/conf/external.routes
@@ -1,4 +1,3 @@
 # External routes, via inbound HODS Proxy
 
-GET         /connectivity-test                  uk.gov.hmrc.apihubapplications.controllers.external.ConnectivityTestController.testing123
 GET         /health                             uk.gov.hmrc.apihubapplications.controllers.external.ConnectivityTestController.testing123


### PR DESCRIPTION
https://jira.tools.tax.service.gov.uk/browse/HIPP-747

Note that we don't actually want to remove the controller as it also serves the /api-hub/health endpoint.