### PR TITLE
HIPP-781: Fix missing primary creds

### DIFF
--- a/app/uk/gov/hmrc/apihubapplications/services/ApplicationsService.scala
+++ b/app/uk/gov/hmrc/apihubapplications/services/ApplicationsService.scala
@@ -81,19 +81,19 @@ class ApplicationsService @Inject()(
           saved <- repository.insert(enriched)
           _ <- emailConnector.sendAddTeamMemberEmail(saved)
           _ <- emailConnector.sendApplicationCreatedEmailToCreator(saved)
-        } yield Right(saved.makePublic())
+        } yield Right(saved)
       case Left(e) => Future.successful(Left(e))
     }
   }
 
   def findAll(): Future[Seq[Application]] = {
-    repository.findAll().map(_.map(_.makePublic()))
+    repository.findAll()
   }
 
   def filter(teamMemberEmail: String, enrich: Boolean)(implicit hc: HeaderCarrier): Future[Either[ApplicationsException, Seq[Application]]] = {
     repository.filter(teamMemberEmail).flatMap {
       applications =>
-        (if (enrich) {
+        if (enrich) {
           ApplicationEnrichers.processAll(
             applications,
             ApplicationEnrichers.secondaryScopeApplicationEnricher _,
@@ -103,14 +103,14 @@ class ApplicationsService @Inject()(
         }
         else {
           Future.successful(Right(applications))
-        }).map(_.map(_.map(_.makePublic())))
+        }
     }
   }
 
   def findById(id: String, enrich: Boolean)(implicit hc: HeaderCarrier): Future[Either[ApplicationsException, Application]] = {
     repository.findById(id).flatMap {
       case Right(application) =>
-        (if (enrich) {
+        if (enrich) {
           ApplicationEnrichers.process(
             application,
             Seq(
@@ -121,7 +121,7 @@ class ApplicationsService @Inject()(
           )
         } else {
           Future.successful(Right(application))
-        }).map(_.map(_.makePublic()))
+        }
       case Left(e) => Future.successful(Left(e))
     }
   }


### PR DESCRIPTION
Broke primary credentials with HIPP-829. Moved the "makePublic" call on applications from the service layer to the controller layer so that internally an application is complete at all times.