### PR TITLE
Unique team name

### DIFF
--- a/app/uk/gov/hmrc/apihubapplications/models/exception/ExceptionRaising.scala
+++ b/app/uk/gov/hmrc/apihubapplications/models/exception/ExceptionRaising.scala
@@ -158,6 +158,12 @@ trait ExceptionRaising {
     }
   }
 
+  object raiseTeamNameNotUniqueException {
+    def forName(name: String): TeamNameNotUniqueException = {
+      log(TeamNameNotUniqueException.forName(name))
+    }
+  }
+
   private def log[T <: ApplicationsException](e: T): T = {
     e match {
       case emailException: EmailException => logger.error("Raised EmailException:", emailException)

--- a/app/uk/gov/hmrc/apihubapplications/models/exception/TeamNameNotUniqueException.scala
+++ b/app/uk/gov/hmrc/apihubapplications/models/exception/TeamNameNotUniqueException.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.apihubapplications.models.exception
+
+case class TeamNameNotUniqueException(message: String) extends ApplicationsException(message, null)
+
+object TeamNameNotUniqueException {
+
+  def forName(name: String): TeamNameNotUniqueException = {
+    TeamNameNotUniqueException(s"Team name $name is not unique and cannot be used")
+  }
+
+}

--- a/app/uk/gov/hmrc/apihubapplications/services/TeamsService.scala
+++ b/app/uk/gov/hmrc/apihubapplications/services/TeamsService.scala
@@ -33,12 +33,12 @@ class TeamsService @Inject()(
   clock: Clock
 )(implicit ec: ExecutionContext) extends Logging with ExceptionRaising {
 
-  def create(newTeam: NewTeam): Future[Team] = {
+  def create(newTeam: NewTeam): Future[Either[ApplicationsException, Team]] = {
     repository.insert(newTeam.toTeam(clock))
   }
 
-  def findAll(teamMember: Option[String]): Future[Seq[Team]] = {
-    repository.findAll(teamMember)
+  def findAll(teamMember: Option[String], name: Option[String]): Future[Seq[Team]] = {
+    repository.findAll(teamMember, name)
   }
 
   def findById(id: String): Future[Either[ApplicationsException, Team]] = {

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -21,7 +21,7 @@ GET        /test-connectivity                                                   
 POST       /deployments/generate                                                    uk.gov.hmrc.apihubapplications.controllers.DeploymentsController.generate()
 
 POST       /teams                                                                   uk.gov.hmrc.apihubapplications.controllers.TeamsController.create()
-GET        /teams                                                                   uk.gov.hmrc.apihubapplications.controllers.TeamsController.findAll(teamMember: Option[String] ?= None)
+GET        /teams                                                                   uk.gov.hmrc.apihubapplications.controllers.TeamsController.findAll(teamMember: Option[String] ?= None, name: Option[String] ?= None)
 GET        /teams/:id                                                               uk.gov.hmrc.apihubapplications.controllers.TeamsController.findById(id: String)
 POST       /teams/:id/members                                                       uk.gov.hmrc.apihubapplications.controllers.TeamsController.addTeamMember(id: String)
 

--- a/test/uk/gov/hmrc/apihubapplications/controllers/TeamsControllerSpec.scala
+++ b/test/uk/gov/hmrc/apihubapplications/controllers/TeamsControllerSpec.scala
@@ -57,7 +57,7 @@ class TeamsControllerSpec
       val newTeam = NewTeam("test-team-name", Seq(teamMember1, teamMember2))
       val saved = newTeam.toTeam(Clock.systemDefaultZone()).setId("test-id")
 
-      when(fixture.teamsService.create(eqTo(newTeam))).thenReturn(Future.successful(saved))
+      when(fixture.teamsService.create(eqTo(newTeam))).thenReturn(Future.successful(Right(saved)))
 
       running(fixture.application) {
         val request = FakeRequest(routes.TeamsController.create())
@@ -95,7 +95,7 @@ class TeamsControllerSpec
     "must return 200 Ok and all teams returned by the service when no teamMember is specified" in {
       val fixture = buildFixture()
 
-      when(fixture.teamsService.findAll(eqTo(None))).thenReturn(Future.successful(Seq(team1, team2, team3)))
+      when(fixture.teamsService.findAll(eqTo(None), eqTo(None))).thenReturn(Future.successful(Seq(team1, team2, team3)))
 
       running(fixture.application) {
         val request = FakeRequest(routes.TeamsController.findAll(None))
@@ -109,7 +109,7 @@ class TeamsControllerSpec
     "must return 200 Ok and all teams returned by the service when a teamMember is specified" in {
       val fixture = buildFixture()
 
-      when(fixture.teamsService.findAll(eqTo(Some(teamMember1.email)))).thenReturn(Future.successful(Seq(team1, team3)))
+      when(fixture.teamsService.findAll(eqTo(Some(teamMember1.email)), eqTo(None))).thenReturn(Future.successful(Seq(team1, team3)))
 
       running(fixture.application) {
         val crypto = fixture.application.injector.instanceOf[ApplicationCrypto]

--- a/test/uk/gov/hmrc/apihubapplications/services/TeamsServiceSpec.scala
+++ b/test/uk/gov/hmrc/apihubapplications/services/TeamsServiceSpec.scala
@@ -45,11 +45,11 @@ class TeamsServiceSpec
       val team = newTeam.toTeam(fixture.clock)
       val saved = team.setId("test-id")
 
-      when(fixture.repository.insert(eqTo(team))).thenReturn(Future.successful(saved))
+      when(fixture.repository.insert(eqTo(team))).thenReturn(Future.successful(Right(saved)))
 
       fixture.service.create(newTeam).map {
         result =>
-          result mustBe saved
+          result mustBe Right(saved)
       }
     }
   }
@@ -58,9 +58,9 @@ class TeamsServiceSpec
     "must return the teams returned by the repository when no teamMember is specified" in {
       val fixture = buildFixture()
 
-      when(fixture.repository.findAll(eqTo(None))).thenReturn(Future.successful(Seq(team1, team2, team3)))
+      when(fixture.repository.findAll(eqTo(None), eqTo(None))).thenReturn(Future.successful(Seq(team1, team2, team3)))
 
-      fixture.service.findAll(None).map {
+      fixture.service.findAll(None, None).map {
         result =>
           result mustBe Seq(team1, team2, team3)
       }
@@ -69,9 +69,9 @@ class TeamsServiceSpec
     "must return the teams returned by the repository when a teamMember is specified" in {
       val fixture = buildFixture()
 
-      when(fixture.repository.findAll(eqTo(Some(teamMember1.email)))).thenReturn(Future.successful(Seq(team1, team3)))
+      when(fixture.repository.findAll(eqTo(Some(teamMember1.email)), eqTo(None))).thenReturn(Future.successful(Seq(team1, team3)))
 
-      fixture.service.findAll(Some(teamMember1.email)).map {
+      fixture.service.findAll(Some(teamMember1.email), None).map {
         result =>
           result mustBe Seq(team1, team3)
       }


### PR DESCRIPTION
Experiment to get unique teams working. Uses a MongoDb case insensitive unique index. When creating a team the service returns 409 Conflict if the name is not unique.