### PR TITLE
HIPP-1076: Add remove team member from team endpoint

### DIFF
--- a/app/uk/gov/hmrc/apihubapplications/models/exception/ExceptionRaising.scala
+++ b/app/uk/gov/hmrc/apihubapplications/models/exception/ExceptionRaising.scala
@@ -154,6 +154,18 @@ trait ExceptionRaising {
     }
   }
 
+  object raiseTeamMemberDoesNotExistException {
+    def forTeam(team: Team): TeamMemberDoesNotExistException = {
+      log(TeamMemberDoesNotExistException.forTeam(team))
+    }
+  }
+
+  object raiseLastTeamMemberException {
+    def forTeam(team: Team): LastTeamMemberException = {
+      log(LastTeamMemberException.forTeam(team))
+    }
+  }
+
   object raiseApimException {
     def unexpectedResponse(statusCode: Int): ApimException = {
       log(ApimException.unexpectedResponse(statusCode))

--- a/app/uk/gov/hmrc/apihubapplications/models/exception/LastTeamMemberException.scala
+++ b/app/uk/gov/hmrc/apihubapplications/models/exception/LastTeamMemberException.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.apihubapplications.models.exception
+
+import uk.gov.hmrc.apihubapplications.models.team.Team
+
+case class LastTeamMemberException(message: String) extends ApplicationsException(message, null)
+
+object LastTeamMemberException {
+
+  def forTeam(team: Team): LastTeamMemberException = {
+    LastTeamMemberException(s"Cannot remove the last member from the '${team.name}' team.")
+  }
+
+}

--- a/app/uk/gov/hmrc/apihubapplications/models/exception/TeamMemberDoesNotExistException.scala
+++ b/app/uk/gov/hmrc/apihubapplications/models/exception/TeamMemberDoesNotExistException.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.apihubapplications.models.exception
+
+import uk.gov.hmrc.apihubapplications.models.team.Team
+
+case class TeamMemberDoesNotExistException(message: String) extends ApplicationsException(message, null)
+
+object TeamMemberDoesNotExistException {
+
+  def forTeam(team: Team): TeamMemberDoesNotExistException = {
+    TeamMemberDoesNotExistException(s"This team member is not part of the '${team.name}' team")
+  }
+
+}

--- a/app/uk/gov/hmrc/apihubapplications/models/team/TeamLenses.scala
+++ b/app/uk/gov/hmrc/apihubapplications/models/team/TeamLenses.scala
@@ -64,6 +64,13 @@ object TeamLenses {
       addTeamMember(TeamMember(email))
     }
 
+    def removeTeamMember(email: String): Team = {
+      teamTeamMembers.set(
+        team,
+        team.teamMembers.filterNot(_.email.equalsIgnoreCase(email))
+      )
+    }
+
     def hasTeamMember(email: String): Boolean = {
       team.teamMembers.exists(_.email.equalsIgnoreCase(email))
     }

--- a/app/uk/gov/hmrc/apihubapplications/services/TeamsService.scala
+++ b/app/uk/gov/hmrc/apihubapplications/services/TeamsService.scala
@@ -76,6 +76,18 @@ class TeamsService @Inject()(
     }
   }
 
+  def removeTeamMember(id: String, encryptedEmail: String): Future[Either[ApplicationsException, Unit]] =
+    repository.findById(id).flatMap {
+      case Right(team) if !team.hasTeamMember(encryptedEmail) =>
+        Future.successful(Left(raiseTeamMemberDoesNotExistException.forTeam(team)))
+      case Right(team) if team.teamMembers.size < 2 =>
+        Future.successful(Left(raiseLastTeamMemberException.forTeam(team)))
+      case Right(team) =>
+        repository.update(team.removeTeamMember(encryptedEmail))
+      case Left(e) =>
+        Future.successful(Left(e))
+    }
+
   def renameTeam(id: String, request: RenameTeamRequest): Future[Either[ApplicationsException, Unit]] = {
     repository.findById(id).flatMap {
       case Right(team) =>

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -29,6 +29,7 @@ GET        /teams                                                               
 GET        /teams/:id                                                               uk.gov.hmrc.apihubapplications.controllers.TeamsController.findById(id: String)
 GET        /teams/name/:name                                                        uk.gov.hmrc.apihubapplications.controllers.TeamsController.findByName(name: String)
 POST       /teams/:id/members                                                       uk.gov.hmrc.apihubapplications.controllers.TeamsController.addTeamMember(id: String)
+DELETE     /teams/:id/members/:encryptedEmail                                       uk.gov.hmrc.apihubapplications.controllers.TeamsController.removeTeamMember(id: String, encryptedEmail: String)
 PUT        /teams/:id                                                               uk.gov.hmrc.apihubapplications.controllers.TeamsController.renameTeam(id: String)
 
 GET        /apis/:publisherRef/deployment-status                                    uk.gov.hmrc.apihubapplications.controllers.DeploymentsController.getDeploymentStatus(publisherRef: String)


### PR DESCRIPTION
AC:
- DELETE /teams/<id>/members/<encrypted-email>
- Inability to delete the last team member
- Return a bad request if a user attempts to remove the last member of the team
- Not Found if team does not exist or the user is not a member of the team