### PR TITLE
HIPP-1615: Refactor to handle APIM deployment responses failures

### DIFF
--- a/app/uk/gov/hmrc/apihubapplications/connectors/APIMConnectorImpl.scala
+++ b/app/uk/gov/hmrc/apihubapplications/connectors/APIMConnectorImpl.scala
@@ -187,15 +187,10 @@ class APIMConnectorImpl @Inject()(
       .map {
         case Right(deployment) => Right(Some(deployment))
         case Left(e) if e.statusCode == 404 => Right(None)
-        case Left(e) if e.statusCode == 403 =>
-          logger.warn(s"Received 403 back from APIM ${environment.toString} whilst looking up publisher reference: $publisherReference and useProxyForSecondary: $useProxyForSecondary. Full url: ${url.toString}")
-          Left(raiseApimException.unexpectedResponse(e.statusCode, context))
         case Left(e) => Left(raiseApimException.unexpectedResponse(e.statusCode, context))
       }
       . recover {
-        case NonFatal(e) =>
-          logger.warn(s"Error occurred while retrieving APIM deployments", e)
-          Left(raiseApimException.unexpectedResponse(500, context))
+        case NonFatal(e) => Left(raiseApimException.error(e, context))
       }
   }
 

--- a/app/uk/gov/hmrc/apihubapplications/controllers/OASController.scala
+++ b/app/uk/gov/hmrc/apihubapplications/controllers/OASController.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.apihubapplications.controllers
 import com.google.inject.{Inject, Singleton}
 import play.api.Logging
 import play.api.libs.json.{Format, JsError, JsSuccess, JsValue, Json}
-import play.api.mvc.{Action, AnyContent, ControllerComponents}
+import play.api.mvc.{Action, AnyContent, ControllerComponents, Request}
 import uk.gov.hmrc.apihubapplications.controllers.actions.IdentifierAction
 import uk.gov.hmrc.apihubapplications.models.apim.{InvalidOasResponse, SuccessfulValidateResponse}
 import uk.gov.hmrc.apihubapplications.models.apim.ValidateResponse

--- a/app/uk/gov/hmrc/apihubapplications/controllers/OASController.scala
+++ b/app/uk/gov/hmrc/apihubapplications/controllers/OASController.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.apihubapplications.controllers
 import com.google.inject.{Inject, Singleton}
 import play.api.Logging
 import play.api.libs.json.{Format, JsError, JsSuccess, JsValue, Json}
-import play.api.mvc.{Action, AnyContent, ControllerComponents, Request}
+import play.api.mvc.{Action, AnyContent, ControllerComponents}
 import uk.gov.hmrc.apihubapplications.controllers.actions.IdentifierAction
 import uk.gov.hmrc.apihubapplications.models.apim.{InvalidOasResponse, SuccessfulValidateResponse}
 import uk.gov.hmrc.apihubapplications.models.apim.ValidateResponse

--- a/app/uk/gov/hmrc/apihubapplications/models/exception/ApimException.scala
+++ b/app/uk/gov/hmrc/apihubapplications/models/exception/ApimException.scala
@@ -29,6 +29,7 @@ object ApimException {
   case object UnexpectedResponse extends ApimIssue
   case object InvalidResponse extends ApimIssue
   case object ServiceNotFound extends ApimIssue
+  case object CallError extends ApimIssue
 
   def apply(message: String, issue: ApimIssue): ApimException = {
     ApimException(message, null, issue)
@@ -59,6 +60,14 @@ object ApimException {
 
   def serviceNotFound(serviceId: String): ApimException = {
     ApimException(s"Cannot find service with serviceId: $serviceId", ServiceNotFound)
+  }
+
+  def error(throwable: Throwable, context: Seq[(String, AnyRef)]): ApimException = {
+    ApimException(
+      ApplicationsException.addContext("Error calling APIM", context),
+      throwable,
+      CallError
+    )
   }
 
 }

--- a/app/uk/gov/hmrc/apihubapplications/models/exception/ExceptionRaising.scala
+++ b/app/uk/gov/hmrc/apihubapplications/models/exception/ExceptionRaising.scala
@@ -178,6 +178,10 @@ trait ExceptionRaising {
     def serviceNotFound(serviceId: String): ApimException = {
       log(ApimException.serviceNotFound(serviceId))
     }
+
+    def error(throwable: Throwable, context: Seq[(String, AnyRef)] = Seq.empty): ApimException = {
+      log(ApimException.error(throwable, context))
+    }
   }
 
   object raiseTeamNotFoundException {

--- a/app/uk/gov/hmrc/apihubapplications/models/requests/DeploymentStatus.scala
+++ b/app/uk/gov/hmrc/apihubapplications/models/requests/DeploymentStatus.scala
@@ -17,9 +17,29 @@
 package uk.gov.hmrc.apihubapplications.models.requests
 
 import play.api.libs.json.{Format, Json}
+import uk.gov.hmrc.apihubapplications.models.application.EnvironmentName
 
-case class DeploymentStatus(primaryVersion: Option[String], secondaryVersion: Option[String])
+sealed trait DeploymentStatus {
+  def environmentName: EnvironmentName
+}
 
 object DeploymentStatus {
+
+  case class Deployed(override val environmentName: EnvironmentName, version: String) extends DeploymentStatus
+
+  case class NotDeployed(override val environmentName: EnvironmentName) extends DeploymentStatus
+
+  case class Unknown(override val environmentName: EnvironmentName) extends DeploymentStatus
+
+  implicit val formatDeployed: Format[Deployed] = Json.format[Deployed]
+  implicit val formatNotDeployed: Format[NotDeployed] = Json.format[NotDeployed]
+  implicit val formatUnknown: Format[Unknown] = Json.format[Unknown]
   implicit val formatDeploymentStatus: Format[DeploymentStatus] = Json.format[DeploymentStatus]
+
+}
+
+case class DeploymentStatuses(statuses: Seq[DeploymentStatus])
+
+object DeploymentStatuses {
+  implicit val formatDeploymentStatuses: Format[DeploymentStatuses] = Json.format[DeploymentStatuses]
 }

--- a/app/uk/gov/hmrc/apihubapplications/models/requests/DeploymentStatus.scala
+++ b/app/uk/gov/hmrc/apihubapplications/models/requests/DeploymentStatus.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.apihubapplications.models.requests
 
-import play.api.libs.json.{Format, Json}
+import play.api.libs.json.{Format, Json, JsonConfiguration, JsonNaming}
 import uk.gov.hmrc.apihubapplications.models.application.EnvironmentName
 
 sealed trait DeploymentStatus {
@@ -30,6 +30,9 @@ object DeploymentStatus {
   case class NotDeployed(override val environmentName: EnvironmentName) extends DeploymentStatus
 
   case class Unknown(override val environmentName: EnvironmentName) extends DeploymentStatus
+
+  private implicit val jsonConfiguration: JsonConfiguration =
+    JsonConfiguration(typeNaming = JsonNaming { fullName => fullName.split('.').last })
 
   implicit val formatDeployed: Format[Deployed] = Json.format[Deployed]
   implicit val formatNotDeployed: Format[NotDeployed] = Json.format[NotDeployed]

--- a/app/uk/gov/hmrc/apihubapplications/services/MetricsService.scala
+++ b/app/uk/gov/hmrc/apihubapplications/services/MetricsService.scala
@@ -23,10 +23,10 @@ import uk.gov.hmrc.apihubapplications.services.MetricsService.MetricsKeys
 @Singleton
 class MetricsService @Inject()(metricRegistry: MetricRegistry) {
 
-  private lazy val apimUnknownFailureMetric: Meter = metricRegistry.meter(MetricsKeys.APIM.unknownFailure)
+  private lazy val apimDeploymentStatusUnknownMetric: Meter = metricRegistry.meter(MetricsKeys.APIM.apimDeploymentStatusUnknown)
 
   def apimUnknownFailure(): Unit = {
-    apimUnknownFailureMetric.mark()
+    apimDeploymentStatusUnknownMetric.mark()
   }
 
 }
@@ -37,7 +37,7 @@ object MetricsService {
 
     object APIM {
 
-      val unknownFailure: String = "apim-unknown-failure"
+      val apimDeploymentStatusUnknown: String = "apim-deployment-status-unknown"
 
     }
 

--- a/app/uk/gov/hmrc/apihubapplications/services/MetricsService.scala
+++ b/app/uk/gov/hmrc/apihubapplications/services/MetricsService.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.apihubapplications.services
+
+import com.codahale.metrics.{Meter, MetricRegistry}
+import com.google.inject.{Inject, Singleton}
+import uk.gov.hmrc.apihubapplications.services.MetricsService.MetricsKeys
+
+@Singleton
+class MetricsService @Inject()(metricRegistry: MetricRegistry) {
+
+  private lazy val apimUnknownFailureMetric: Meter = metricRegistry.meter(MetricsKeys.APIM.unknownFailure)
+
+  def apimUnknownFailure(): Unit = {
+    apimUnknownFailureMetric.mark()
+  }
+
+}
+
+object MetricsService {
+
+  object MetricsKeys {
+
+    object APIM {
+
+      val unknownFailure: String = "apim-unknown-failure"
+
+    }
+
+  }
+
+}
+

--- a/test/uk/gov/hmrc/apihubapplications/models/requests/DeploymentStatusSpec.scala
+++ b/test/uk/gov/hmrc/apihubapplications/models/requests/DeploymentStatusSpec.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.apihubapplications.models.requests
+
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
+import play.api.libs.json.Json
+import uk.gov.hmrc.apihubapplications.models.application.Primary
+import uk.gov.hmrc.apihubapplications.models.requests.DeploymentStatus.*
+import uk.gov.hmrc.apihubapplications.models.requests.DeploymentStatus.NotDeployed
+
+class DeploymentStatusSpec extends AnyFreeSpec with Matchers{
+
+  "DeploymentStatus" - {
+    "must serialize a deployment status into the expected json" in {
+      val deploymentStatus: DeploymentStatus = NotDeployed(Primary)
+      val json = Json.prettyPrint(Json.toJson[DeploymentStatus](deploymentStatus))
+
+      json mustBe """{
+                    |  "environmentName" : "primary",
+                    |  "_type" : "NotDeployed"
+                    |}""".stripMargin
+    }
+  }
+
+}

--- a/test/uk/gov/hmrc/apihubapplications/services/DeploymentsServiceSpec.scala
+++ b/test/uk/gov/hmrc/apihubapplications/services/DeploymentsServiceSpec.scala
@@ -127,23 +127,6 @@ class DeploymentsServiceSpec
     }
   }
 
-  "getDeployment" - {
-    "must pass the request to the APIM connector and return the response" in {
-      val fixture = buildFixture()
-      val publisherRef = "test-publisher-ref"
-      val deploymentResponse = SuccessfulDeploymentResponse("test-id", "1")
-
-      when(fixture.apimConnector.getDeployment(any, any)(any)).thenReturn(Future.successful(Right(Some(deploymentResponse))))
-
-      fixture.deploymentsService.getDeployment(publisherRef, Primary)(HeaderCarrier()).map {
-        result =>
-          result mustBe Right(Some(deploymentResponse))
-          verify(fixture.apimConnector).getDeployment(eqTo(publisherRef), eqTo(Primary))(any)
-          succeed
-      }
-    }
-  }
-
   "getDeployments" - {
     "must pass the request to the APIM connector and return the response" in {
       val fixture = buildFixture()

--- a/test/uk/gov/hmrc/apihubapplications/services/DeploymentsServiceSpec.scala
+++ b/test/uk/gov/hmrc/apihubapplications/services/DeploymentsServiceSpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.apihubapplications.services
 
-import org.mockito.ArgumentMatchers.{any, eq as eqTo}
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito.{times, verify, when}
 import org.scalatest.EitherValues
 import org.scalatest.freespec.AsyncFreeSpec
@@ -27,8 +27,10 @@ import play.api.http.Status.BAD_REQUEST
 import uk.gov.hmrc.apihubapplications.connectors.{APIMConnector, EmailConnector, IntegrationCatalogueConnector}
 import uk.gov.hmrc.apihubapplications.models.api.ApiTeam
 import uk.gov.hmrc.apihubapplications.models.apim.*
-import uk.gov.hmrc.apihubapplications.models.application.{Primary, TeamMember}
+import uk.gov.hmrc.apihubapplications.models.application.{Primary, Secondary, TeamMember}
+import uk.gov.hmrc.apihubapplications.models.exception.ApimException.unexpectedResponse
 import uk.gov.hmrc.apihubapplications.models.exception.{ApiNotFoundException, ApimException, EmailException, IntegrationCatalogueException}
+import uk.gov.hmrc.apihubapplications.models.requests.DeploymentStatus.{Deployed, NotDeployed, Unknown}
 import uk.gov.hmrc.apihubapplications.models.team.Team
 import uk.gov.hmrc.apihubapplications.testhelpers.ApiDetailGenerators
 import uk.gov.hmrc.http.HeaderCarrier
@@ -137,6 +139,57 @@ class DeploymentsServiceSpec
         result =>
           result mustBe Right(Some(deploymentResponse))
           verify(fixture.apimConnector).getDeployment(eqTo(publisherRef), eqTo(Primary))(any)
+          succeed
+      }
+    }
+  }
+
+  "getDeployments" - {
+    "must pass the request to the APIM connector and return the response" in {
+      val fixture = buildFixture()
+      val publisherRef = "test-publisher-ref"
+      val deploymentResponse = SuccessfulDeploymentResponse("test-id", "1")
+
+      when(fixture.apimConnector.getDeployment(any, any)(any)).thenReturn(Future.successful(Right(Some(deploymentResponse))))
+
+      fixture.deploymentsService.getDeployments(publisherRef)(HeaderCarrier()).map {
+        result =>
+          result mustBe Seq(Deployed(Primary, "1"), Deployed(Secondary, "1"))
+          verify(fixture.apimConnector).getDeployment(eqTo(publisherRef), eqTo(Primary))(any)
+          verify(fixture.apimConnector).getDeployment(eqTo(publisherRef), eqTo(Secondary))(any)
+          succeed
+      }
+    }
+    "must handle missing valid responses and return NotDeployed" in {
+      val fixture = buildFixture()
+      val publisherRef = "test-publisher-ref"
+      val deploymentResponse = SuccessfulDeploymentResponse("test-id", "1")
+
+      when(fixture.apimConnector.getDeployment(any, eqTo(Primary))(any)).thenReturn(Future.successful(Right(Some(deploymentResponse))))
+      when(fixture.apimConnector.getDeployment(any, eqTo(Secondary))(any)).thenReturn(Future.successful(Right(None)))
+
+      fixture.deploymentsService.getDeployments(publisherRef)(HeaderCarrier()).map {
+        result =>
+          result mustBe Seq(Deployed(Primary, "1"), NotDeployed(Secondary))
+          verify(fixture.apimConnector).getDeployment(eqTo(publisherRef), eqTo(Primary))(any)
+          verify(fixture.apimConnector).getDeployment(eqTo(publisherRef), eqTo(Secondary))(any)
+          succeed
+      }
+    }
+    "must handle response failures, return Unknown and record the failure on a metric" in {
+      val fixture = buildFixture()
+      val publisherRef = "test-publisher-ref"
+      val deploymentResponse = SuccessfulDeploymentResponse("test-id", "1")
+
+      when(fixture.apimConnector.getDeployment(any, eqTo(Primary))(any)).thenReturn(Future.successful(Right(Some(deploymentResponse))))
+      when(fixture.apimConnector.getDeployment(any, eqTo(Secondary))(any)).thenReturn(Future.successful(Left(unexpectedResponse(500))))
+
+      fixture.deploymentsService.getDeployments(publisherRef)(HeaderCarrier()).map {
+        result =>
+          result mustBe Seq(Deployed(Primary, "1"), Unknown(Secondary))
+          verify(fixture.apimConnector).getDeployment(eqTo(publisherRef), eqTo(Primary))(any)
+          verify(fixture.apimConnector).getDeployment(eqTo(publisherRef), eqTo(Secondary))(any)
+          verify(fixture.metricsService).apimUnknownFailure()
           succeed
       }
     }
@@ -328,7 +381,8 @@ class DeploymentsServiceSpec
                               integrationCatalogueConnector: IntegrationCatalogueConnector,
                               deploymentsService: DeploymentsService,
                               teamsService: TeamsService,
-                              emailConnector: EmailConnector
+                              emailConnector: EmailConnector,
+                              metricsService: MetricsService,
                             )
 
   private def buildFixture(): Fixture = {
@@ -336,9 +390,10 @@ class DeploymentsServiceSpec
     val integrationCatalogueConnector = mock[IntegrationCatalogueConnector]
     val emailConnector = mock[EmailConnector]
     val teamsService = mock[TeamsService]
-    val deploymentsService = new DeploymentsService(apimConnector, integrationCatalogueConnector, emailConnector, teamsService)
+    val metricsService = mock[MetricsService]
+    val deploymentsService = new DeploymentsService(apimConnector, integrationCatalogueConnector, emailConnector, teamsService, metricsService)
 
-    Fixture(apimConnector, integrationCatalogueConnector, deploymentsService, teamsService, emailConnector)
+    Fixture(apimConnector, integrationCatalogueConnector, deploymentsService, teamsService, emailConnector, metricsService)
   }
 
 }


### PR DESCRIPTION
APIM outages would prevent our users to see deployment statuses. Instead of propagating the outage errors, we are just returning different deployment status types.