### PR TITLE
Environment parity connector spike

### DIFF
--- a/app/uk/gov/hmrc/apihubapplications/config/Module.scala
+++ b/app/uk/gov/hmrc/apihubapplications/config/Module.scala
@@ -16,9 +16,9 @@
 
 package uk.gov.hmrc.apihubapplications.config
 
-import play.api.inject.{Binding, bind => bindz}
+import play.api.inject.{Binding, bind as bindz}
 import play.api.{Configuration, Environment}
-import uk.gov.hmrc.apihubapplications.connectors.{APIMConnector, APIMConnectorImpl, EmailConnector, EmailConnectorImpl, IdmsConnector, IdmsConnectorImpl, IntegrationCatalogueConnector, IntegrationCatalogueConnectorImpl}
+import uk.gov.hmrc.apihubapplications.connectors.{APIMConnector, APIMConnectorEnvironmentParityImpl, APIMConnectorImpl, EmailConnector, EmailConnectorImpl, IdmsConnector, IdmsConnectorImpl, IntegrationCatalogueConnector, IntegrationCatalogueConnectorImpl}
 import uk.gov.hmrc.apihubapplications.controllers.actions.{AuthenticatedIdentifierAction, IdentifierAction}
 import uk.gov.hmrc.apihubapplications.services.{ApplicationsApiService, ApplicationsApiServiceImpl, ApplicationsCredentialsService, ApplicationsCredentialsServiceImpl, ApplicationsLifecycleService, ApplicationsLifecycleServiceImpl, ApplicationsSearchService, ApplicationsSearchServiceImpl}
 import uk.gov.hmrc.apihubapplications.tasks.DatabaseStatisticMetricOrchestratorTask
@@ -38,7 +38,7 @@ class Module extends play.api.inject.Module {
       bindz(classOf[MetricOrchestrator]).toProvider(classOf[DatabaseStatisticsMetricOrchestratorProvider]).eagerly(),
       bindz(classOf[DatabaseStatisticMetricOrchestratorTask]).toSelf.eagerly(),
       bindz(classOf[EmailConnector]).to(classOf[EmailConnectorImpl]).eagerly(),
-      bindz(classOf[APIMConnector]).to(classOf[APIMConnectorImpl]).eagerly(),
+      bindz(classOf[APIMConnector]).to(apimConnectorBinding(configuration)).eagerly(),
       bindz(classOf[IntegrationCatalogueConnector]).to(classOf[IntegrationCatalogueConnectorImpl]).eagerly(),
       bindz(classOf[ApplicationsApiService]).to(classOf[ApplicationsApiServiceImpl]).eagerly(),
       bindz(classOf[ApplicationsCredentialsService]).to(classOf[ApplicationsCredentialsServiceImpl]).eagerly(),
@@ -53,6 +53,15 @@ class Module extends play.api.inject.Module {
     }
 
     bindings ++ authTokenInitialiserBindings
+  }
+
+  private def apimConnectorBinding(configuration: Configuration): Class[? <: APIMConnector] = {
+    if (configuration.get[Boolean]("features.environment-parity")) {
+      classOf[APIMConnectorEnvironmentParityImpl]
+    }
+    else {
+      classOf[APIMConnectorImpl]
+    }
   }
 
 }

--- a/app/uk/gov/hmrc/apihubapplications/connectors/APIMConnectorEnvironmentParityImpl.scala
+++ b/app/uk/gov/hmrc/apihubapplications/connectors/APIMConnectorEnvironmentParityImpl.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.apihubapplications.connectors
+import uk.gov.hmrc.apihubapplications.models.api.EgressGateway
+import uk.gov.hmrc.apihubapplications.models.apim.{ApiDeployment, DeploymentDetails, DeploymentResponse, DeploymentsRequest, DeploymentsResponse, RedeploymentRequest, ValidateResponse}
+import uk.gov.hmrc.apihubapplications.models.application.EnvironmentName
+import uk.gov.hmrc.apihubapplications.models.exception.ApimException
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.Future
+
+class APIMConnectorEnvironmentParityImpl extends APIMConnector {
+
+  override def validateInPrimary(oas: String)(implicit hc: HeaderCarrier): Future[Either[ApimException, ValidateResponse]] = ???
+
+  override def deployToSecondary(request: DeploymentsRequest)(implicit hc: HeaderCarrier): Future[Either[ApimException, DeploymentsResponse]] = ???
+
+  override def redeployToSecondary(publisherReference: String, request: RedeploymentRequest)(implicit hc: HeaderCarrier): Future[Either[ApimException, DeploymentsResponse]] = ???
+
+  override def getDeployment(publisherReference: String, environment: EnvironmentName)(implicit hc: HeaderCarrier): Future[Either[ApimException, Option[DeploymentResponse]]] = ???
+
+  override def getDeploymentDetails(publisherReference: String)(implicit hc: HeaderCarrier): Future[Either[ApimException, DeploymentDetails]] = ???
+
+  override def promoteToProduction(publisherReference: String)(implicit hc: HeaderCarrier): Future[Either[ApimException, DeploymentsResponse]] = ???
+
+  override def getDeployments(environment: EnvironmentName)(implicit hc: HeaderCarrier): Future[Either[ApimException, Seq[ApiDeployment]]] = ???
+
+  override def listEgressGateways()(implicit hc: HeaderCarrier): Future[Either[ApimException, Seq[EgressGateway]]] = ???
+
+}

--- a/app/uk/gov/hmrc/apihubapplications/controllers/EnvironmentParityTestController.scala
+++ b/app/uk/gov/hmrc/apihubapplications/controllers/EnvironmentParityTestController.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.apihubapplications.controllers
+
+import com.google.inject.{Inject, Singleton}
+import play.api.libs.json.Json
+import play.api.mvc.{Action, AnyContent, ControllerComponents}
+import uk.gov.hmrc.apihubapplications.connectors.APIMConnectorEnvironmentParityImpl
+import uk.gov.hmrc.apihubapplications.controllers.actions.IdentifierAction
+import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
+
+import scala.concurrent.ExecutionContext
+
+@Singleton
+class EnvironmentParityTestController @Inject()(
+  cc: ControllerComponents,
+  identify: IdentifierAction,
+  apimConnector: APIMConnectorEnvironmentParityImpl
+)(implicit ec: ExecutionContext) extends BackendController(cc) {
+
+  def etc(): Action[AnyContent] = identify.async {
+    implicit request =>
+      apimConnector.listEgressGateways().map {
+        case Right(egresses) => Ok(Json.toJson(egresses))
+        case Left(e) => throw e
+      }
+  }
+
+}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -174,3 +174,7 @@ mongoJob {
     enabled = false
     className = "uk.gov.hmrc.apihubapplications.mongojobs.ExampleJob"
 }
+
+features {
+  environment-parity = false
+}


### PR DESCRIPTION
This adds a second APIM connector, `APIMConnectorEnvironmentParityImpl`, although it's just a skeleton implementation. This could use different configuration than the existing connector.

In `application.conf` there is a new configuration value, `features.environment-parity`. This is used by `Module` to determine which connector implementation should be used at runtime. We could therefore switch implementation by updating this value in an environment configuration file such as `app-config-qa` and redeploying.

A controller, `EnvironmentParityTestController`, has been added that explicitly uses `APIMConnectorEnvironmentParityImpl` and could test our connectivity to new APIM environments via the platform API while existing code uses the original connector.
