### PR TITLE
HIPP-1680: Use api-hub-apim-stubs

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -85,19 +85,18 @@ microservice {
 
     idms-primary {
       host = localhost
-      port = 15022
-      path = identity-management-service-stubs
-      clientId = idms-stub-client-id
-      secret = idms-stub-secret
+      port = 15026
+      path = api-hub-apim-stubs
+      clientId = apim-stub-client-id
+      secret = apim-stub-secret
     }
 
     idms-secondary {
       host = localhost
-      port = 15021
-      path = identity-management-service-proxy
-      clientId = idms-stub-client-id
-      secret = idms-stub-secret
-      apiKey = ebridge-api-key
+      port = 15026
+      path = api-hub-apim-stubs
+      clientId = apim-stub-client-id
+      secret = apim-stub-secret
     }
 
     hip {
@@ -127,19 +126,18 @@ microservice {
 
     apim-primary {
       host = localhost
-      port = 15025
-      path = simple-api-deployment-stubs
-      clientId = simple-api-deployment-client-id
-      secret = simple-api-deployment-secret
+      port = 15026
+      path = api-hub-apim-stubs
+      clientId = apim-stub-client-id
+      secret = apim-stub-secret
     }
 
     apim-secondary {
       host = localhost
-      port = 15025
-      path = simple-api-deployment-stubs
-      apiKey = ebridge-api-key
-      clientId = simple-api-deployment-client-id
-      secret = simple-api-deployment-secret
+      port = 15026
+      path = api-hub-apim-stubs
+      clientId = apim-stub-client-id
+      secret = apim-stub-secret
     }
 
     integration-catalogue {


### PR DESCRIPTION
https://jira.tools.tax.service.gov.uk/browse/HIPP-1680

We don't have the apim-proxy implementation yet so the secondary/test connections go direct to the stubs. That should change on https://jira.tools.tax.service.gov.uk/browse/HIPP-1666.