### PR TITLE
Hipp 1764 bug fix

### DIFF
--- a/app/uk/gov/hmrc/apihubapplications/services/OASService.scala
+++ b/app/uk/gov/hmrc/apihubapplications/services/OASService.scala
@@ -55,7 +55,7 @@ class OASService @Inject()(apimConnector: APIMConnector) {
   }
 
   private def isValidOasTitle(oas: String) = oasTitle(oas).forall(title => {
-    title.length <= oasTitleMaxSize
+    title.replace("\"", "").length <= oasTitleMaxSize
   })
 
   private def oasTitle(oas: String): Option[String] = {

--- a/app/uk/gov/hmrc/apihubapplications/services/OASService.scala
+++ b/app/uk/gov/hmrc/apihubapplications/services/OASService.scala
@@ -15,6 +15,7 @@
  */
 
 package uk.gov.hmrc.apihubapplications.services
+import com.fasterxml.jackson.databind.module.SimpleModule
 import com.google.inject.{Inject, Singleton}
 import io.circe.yaml
 import play.api.Logging
@@ -22,12 +23,11 @@ import uk.gov.hmrc.apihubapplications.connectors.APIMConnector
 import uk.gov.hmrc.apihubapplications.models.apim.{Error as ApimError, *}
 import uk.gov.hmrc.apihubapplications.models.exception.ApimException
 import uk.gov.hmrc.http.HeaderCarrier
-import com.fasterxml.jackson.databind.module.SimpleModule
 //import io.swagger.oas.inflector.examples.ExampleBuilder
 import io.swagger.oas.inflector.processors.JsonNodeExampleSerializer
 import io.swagger.v3.oas.models.media.{Content, MediaType, Schema}
-import io.swagger.v3.oas.models.{Components, OpenAPI, Operation, PathItem, Paths}
 import io.swagger.v3.oas.models.servers.Server
+import io.swagger.v3.oas.models.*
 import io.swagger.v3.parser.OpenAPIV3Parser
 import io.swagger.v3.parser.core.models.{ParseOptions, SwaggerParseResult}
 

--- a/app/uk/gov/hmrc/apihubapplications/services/OASService.scala
+++ b/app/uk/gov/hmrc/apihubapplications/services/OASService.scala
@@ -16,33 +16,42 @@
 
 package uk.gov.hmrc.apihubapplications.services
 import com.google.inject.{Inject, Singleton}
-import io.circe.{yaml}
+import io.circe.yaml
+import play.api.Logging
 import uk.gov.hmrc.apihubapplications.connectors.APIMConnector
 import uk.gov.hmrc.apihubapplications.models.apim.{Error as ApimError, *}
 import uk.gov.hmrc.apihubapplications.models.exception.ApimException
 import uk.gov.hmrc.http.HeaderCarrier
+import com.fasterxml.jackson.databind.module.SimpleModule
+//import io.swagger.oas.inflector.examples.ExampleBuilder
+import io.swagger.oas.inflector.processors.JsonNodeExampleSerializer
+import io.swagger.v3.oas.models.media.{Content, MediaType, Schema}
+import io.swagger.v3.oas.models.{Components, OpenAPI, Operation, PathItem, Paths}
+import io.swagger.v3.oas.models.servers.Server
+import io.swagger.v3.parser.OpenAPIV3Parser
+import io.swagger.v3.parser.core.models.{ParseOptions, SwaggerParseResult}
 
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class OASService @Inject()(apimConnector: APIMConnector) {
 
-  val oasTitleError = ApimError("APIM", "Oas title is too long.")
   val oasTitleMaxSize = 46
 
   def validateInPrimary(oas: String, validateTitle: Boolean)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Either[ApimException, ValidateResponse]] = {
 
     if (validateTitle) {
+      val title = oasTitle(oas)
       val validOasTitle = isValidOasTitle(oas)
       apimConnector.validateInPrimary(oas) map {
         case Right(SuccessfulValidateResponse) if validOasTitle => Right(SuccessfulValidateResponse)
-        case Right(SuccessfulValidateResponse) => Right(InvalidOasResponse(newFailuresResponse))
+        case Right(SuccessfulValidateResponse) => Right(InvalidOasResponse(newFailuresResponse(title)))
         case Right(invalidOasResponse: InvalidOasResponse) if validOasTitle => Right(invalidOasResponse)
         case Right(invalidOasResponse: InvalidOasResponse) =>
           val failure = invalidOasResponse.failure
           Right(invalidOasResponse.copy(
             failure = failure.copy(
-              errors = Some(failure.errors.toList.flatten ++ Seq(oasTitleError)))))
+              errors = Some(failure.errors.toList.flatten ++ Seq(oasTitleError(title))))))
         case Left(exception) => Left(exception)
       }
     } else {
@@ -50,19 +59,25 @@ class OASService @Inject()(apimConnector: APIMConnector) {
     }
   }
 
-  private def newFailuresResponse = {
-    FailuresResponse("BAD_REQUEST", s"oas title is longer than $oasTitleMaxSize characters", Some(Seq(oasTitleError)))
+  private def oasTitleError(maybeTitle: Option[String]) = {
+    maybeTitle match {
+      case Some(title) => ApimError("APIM", s"Oas title has ${title.length} characters. Maximum is $oasTitleMaxSize.")
+      case _ => ApimError("APIM", "Oas has no title.")
+    }
+  }
+  
+  private def newFailuresResponse(maybeTitle: Option[String]) = {
+    maybeTitle match {
+      case Some(title) => FailuresResponse("BAD_REQUEST", s"oas title is longer than $oasTitleMaxSize characters", Some(Seq(oasTitleError(maybeTitle))))
+      case _ => FailuresResponse("BAD_REQUEST", "Oas has no title.", Some(Seq(oasTitleError(maybeTitle))))
+    }
   }
 
-  private def isValidOasTitle(oas: String) = oasTitle(oas).forall(title => {
-    title.replace("\"", "").length <= oasTitleMaxSize
-  })
+  private def isValidOasTitle(oas: String) = oasTitle(oas).exists(title => title.length <= oasTitleMaxSize)
 
-  private def oasTitle(oas: String): Option[String] = {
-    val oasYamlOrFail = yaml.parser.parse(oas)
-    oasYamlOrFail.toOption.flatMap(
-      _.findAllByKey("title").headOption.map(_.toString)
-    )
-  }
+  private def oasTitle(oas: String): Option[String] = parse(oas) map (_.getInfo) map (_.getTitle)
+
+  private def parse(openApiSpecification: String): Option[OpenAPI] = 
+    Option(new OpenAPIV3Parser().readContents(openApiSpecification, null, null).getOpenAPI)
 
 }

--- a/app/uk/gov/hmrc/apihubapplications/services/OASService.scala
+++ b/app/uk/gov/hmrc/apihubapplications/services/OASService.scala
@@ -17,18 +17,17 @@
 package uk.gov.hmrc.apihubapplications.services
 import com.fasterxml.jackson.databind.module.SimpleModule
 import com.google.inject.{Inject, Singleton}
-import io.circe.yaml
+import io.swagger.oas.inflector.processors.JsonNodeExampleSerializer
+import io.swagger.v3.oas.models.*
+import io.swagger.v3.oas.models.media.{Content, MediaType, Schema}
+import io.swagger.v3.oas.models.servers.Server
+import io.swagger.v3.parser.OpenAPIV3Parser
+import io.swagger.v3.parser.core.models.{ParseOptions, SwaggerParseResult}
 import play.api.Logging
 import uk.gov.hmrc.apihubapplications.connectors.APIMConnector
 import uk.gov.hmrc.apihubapplications.models.apim.{Error as ApimError, *}
 import uk.gov.hmrc.apihubapplications.models.exception.ApimException
 import uk.gov.hmrc.http.HeaderCarrier
-import io.swagger.oas.inflector.processors.JsonNodeExampleSerializer
-import io.swagger.v3.oas.models.media.{Content, MediaType, Schema}
-import io.swagger.v3.oas.models.servers.Server
-import io.swagger.v3.oas.models.*
-import io.swagger.v3.parser.OpenAPIV3Parser
-import io.swagger.v3.parser.core.models.{ParseOptions, SwaggerParseResult}
 
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/app/uk/gov/hmrc/apihubapplications/services/OASService.scala
+++ b/app/uk/gov/hmrc/apihubapplications/services/OASService.scala
@@ -17,13 +17,8 @@
 package uk.gov.hmrc.apihubapplications.services
 import com.fasterxml.jackson.databind.module.SimpleModule
 import com.google.inject.{Inject, Singleton}
-import io.swagger.oas.inflector.processors.JsonNodeExampleSerializer
-import io.swagger.v3.oas.models.*
-import io.swagger.v3.oas.models.media.{Content, MediaType, Schema}
-import io.swagger.v3.oas.models.servers.Server
+import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.parser.OpenAPIV3Parser
-import io.swagger.v3.parser.core.models.{ParseOptions, SwaggerParseResult}
-import play.api.Logging
 import uk.gov.hmrc.apihubapplications.connectors.APIMConnector
 import uk.gov.hmrc.apihubapplications.models.apim.{Error as ApimError, *}
 import uk.gov.hmrc.apihubapplications.models.exception.ApimException
@@ -63,7 +58,7 @@ class OASService @Inject()(apimConnector: APIMConnector) {
       case _ => ApimError("APIM", "Oas has no title.")
     }
   }
-  
+
   private def newFailuresResponse(maybeTitle: Option[String]) = {
     maybeTitle match {
       case Some(title) => FailuresResponse("BAD_REQUEST", s"oas title is longer than $oasTitleMaxSize characters", Some(Seq(oasTitleError(maybeTitle))))
@@ -75,7 +70,7 @@ class OASService @Inject()(apimConnector: APIMConnector) {
 
   private def oasTitle(oas: String): Option[String] = parse(oas) map (_.getInfo) map (_.getTitle)
 
-  private def parse(openApiSpecification: String): Option[OpenAPI] = 
+  private def parse(openApiSpecification: String): Option[OpenAPI] =
     Option(new OpenAPIV3Parser().readContents(openApiSpecification, null, null).getOpenAPI)
 
 }

--- a/app/uk/gov/hmrc/apihubapplications/services/OASService.scala
+++ b/app/uk/gov/hmrc/apihubapplications/services/OASService.scala
@@ -15,7 +15,6 @@
  */
 
 package uk.gov.hmrc.apihubapplications.services
-import com.fasterxml.jackson.databind.module.SimpleModule
 import com.google.inject.{Inject, Singleton}
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.parser.OpenAPIV3Parser

--- a/app/uk/gov/hmrc/apihubapplications/services/OASService.scala
+++ b/app/uk/gov/hmrc/apihubapplications/services/OASService.scala
@@ -23,7 +23,6 @@ import uk.gov.hmrc.apihubapplications.connectors.APIMConnector
 import uk.gov.hmrc.apihubapplications.models.apim.{Error as ApimError, *}
 import uk.gov.hmrc.apihubapplications.models.exception.ApimException
 import uk.gov.hmrc.http.HeaderCarrier
-//import io.swagger.oas.inflector.examples.ExampleBuilder
 import io.swagger.oas.inflector.processors.JsonNodeExampleSerializer
 import io.swagger.v3.oas.models.media.{Content, MediaType, Schema}
 import io.swagger.v3.oas.models.servers.Server

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -14,9 +14,16 @@ object AppDependencies {
     "uk.gov.hmrc.mongo"       %% "hmrc-mongo-metrix-play-30"    % hmrcMongoVersion,
     "uk.gov.hmrc"             %% "internal-auth-client-play-30" % internalAuthVersion,
     "uk.gov.hmrc"             %% "crypto-json-play-30"          % "8.1.0",
-    "io.circe"                %% "circe-yaml"                   % "0.14.2",
-    "io.circe"                %% "circe-generic"                % "0.14.6",
-    "io.circe"                %% "circe-parser"                 % "0.14.6"
+    "io.swagger.parser.v3" % "swagger-parser" % "2.1.22"
+      excludeAll(
+      ExclusionRule("com.fasterxml.jackson.core", "jackson-databind"),
+      ExclusionRule("com.fasterxml.jackson.datatype", "jackson-datatype-jsr310")
+    ),
+    "io.swagger" % "swagger-inflector" % "2.0.12"
+      excludeAll(
+      ExclusionRule("com.fasterxml.jackson.core", "jackson-databind"),
+      ExclusionRule("com.fasterxml.jackson.datatype", "jackson-datatype-jsr310")
+    ),
   )
 
   val test = Seq(

--- a/test/uk/gov/hmrc/apihubapplications/services/OASServiceSpec.scala
+++ b/test/uk/gov/hmrc/apihubapplications/services/OASServiceSpec.scala
@@ -55,10 +55,28 @@ class OASServiceSpec
       }
     }
 
+    "must return a validation success result for a valid oas when title is 46 chars" in {
+      val fixture = buildFixture()
+
+      val title = "valid oas content but with a title of 46 chars"
+      assert(title.length == 46)
+      val oas = s"title: $title"
+      val validResponse = SuccessfulValidateResponse
+
+      when(fixture.apimConnector.validateInPrimary(eqTo(oas))(any)).thenReturn(Future.successful(Right(validResponse)))
+
+      fixture.oasService.validateInPrimary(oas, true)(HeaderCarrier()).map {
+        result =>
+          result.value mustBe validResponse
+      }
+    }
+
     "must return a validation result for a valid oas but with title validation error when title too long" in {
       val fixture = buildFixture()
 
-      val oas = "title: valid oas content but with a title that is much longer than the maximum forty six characters"
+      val title = "valid oas content but with a title that is much longer than the maximum forty six characters"
+      assert(title.length > 46)
+      val oas = s"title: $title"
       val validResponse = SuccessfulValidateResponse
       val invalidResponse = InvalidOasResponse(FailuresResponse("BAD_REQUEST","oas title is longer than 46 characters", Some(Seq(ApimError("APIM", "Oas title is too long.")))))
 


### PR DESCRIPTION
Fix for some unexpected behaviour. The circe yaml parser will wrap a yaml implicit string with quotes, and serialize escaped strings, resulting in an incorrect string being subject to the length check. It does not do this with integer values.

![image](https://github.com/user-attachments/assets/40b811a4-e7c5-410d-a5d5-cc8ebc2ecc63)

